### PR TITLE
Convert inf to nan and set to 0

### DIFF
--- a/openstef_dbc/services/write.py
+++ b/openstef_dbc/services/write.py
@@ -365,7 +365,8 @@ class Write:
         df = df.set_index("date")
 
         # Convert nan / inf since these are not supported in influx
-        df = df.replace([np.inf, -np.inf], np.nan)
+        df = df.replace([np.inf], 9999.9)
+        df = df.replace([np.-inf], -9999.9)
         df = df.fillna(value=0)
 
         # Specify correct types

--- a/openstef_dbc/services/write.py
+++ b/openstef_dbc/services/write.py
@@ -348,6 +348,7 @@ class Write:
 
     def write_kpi(self, pj, kpis):
         """Method that writes the key performance indicators of a pid to an influx DB.
+        Note that NaN / Inf are converted to 0, since these are not supported in Influx.
 
         Args:
             pj: a KTP prediction job
@@ -363,6 +364,8 @@ class Write:
         # add date
         df = df.set_index("date")
 
+        # Convert nan / inf since these are not supported in influx
+        df = df.replace([np.inf, -np.inf], np.nan)
         df = df.fillna(value=0)
 
         # Specify correct types

--- a/openstef_dbc/services/write.py
+++ b/openstef_dbc/services/write.py
@@ -366,7 +366,7 @@ class Write:
 
         # Convert nan / inf since these are not supported in influx
         df = df.replace([np.inf], 9999.9)
-        df = df.replace([np.-inf], -9999.9)
+        df = df.replace([-np.inf], -9999.9)
         df = df.fillna(value=0)
 
         # Specify correct types


### PR DESCRIPTION
Fixes bug KTPS-1867. 'inf' cannot be stored in influx. 
This turns it to 0 (just like nans).

Are you okay with this proposed change?