### PR TITLE
Bugfix/ktps 3249

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # NEVER check in our secrets file
 secrets.yaml
 # Ignore these folders
+.ignore/
 trained_models/
 docs/build/
 certificates/
@@ -15,6 +16,7 @@ ktprognoses.egg-info/
 # Ignore these files
 .DS_Store
 git-template
+debug.ipynb
 
 # default Python .gitignore template: https://raw.githubusercontent.com/github/gitignore/master/Python.gitignore
 

--- a/openstef_dbc/services/ems.py
+++ b/openstef_dbc/services/ems.py
@@ -130,9 +130,9 @@ class Ems:
             result = pd.concat(
                 [
                     result_raw[0][["_time", "_value"]].rename(
-                        columns={"_value": "load"}
+                        columns={"_value": result_raw[0]["result"][0]}
                     ),
-                    result_raw[1][["_value"]].rename(columns={"_value": "nEntries"}),
+                    result_raw[1][["_value"]].rename(columns={"_value": result_raw[1]["result"][0]}),
                 ],
                 axis=1,
             ).set_index("_time")

--- a/openstef_dbc/services/ems.py
+++ b/openstef_dbc/services/ems.py
@@ -128,7 +128,7 @@ class Ems:
 
         if aggregated:
             # `result_raw`, contains the outcome of a flux query that returns a list of two dataframes.
-            # The order of the two dataframes within the list can differ from one run to the next. 
+            # The order of the two dataframes within the list can differ from one run to the next.
             # Therefore the renaming of the `_value` column is done dynamically.
             result = pd.concat(
                 [

--- a/openstef_dbc/services/ems.py
+++ b/openstef_dbc/services/ems.py
@@ -127,6 +127,9 @@ class Ems:
             return pd.DataFrame()
 
         if aggregated:
+            # `result_raw`, contains the outcome of a flux query that returns a list of two dataframes.
+            # The order of the two dataframes within the list can differ from one run to the next. 
+            # Therefore the renaming of the `_value` column is done dynamically.
             result = pd.concat(
                 [
                     result_raw[0][["_time", "_value"]].rename(

--- a/openstef_dbc/services/ems.py
+++ b/openstef_dbc/services/ems.py
@@ -132,7 +132,9 @@ class Ems:
                     result_raw[0][["_time", "_value"]].rename(
                         columns={"_value": result_raw[0]["result"][0]}
                     ),
-                    result_raw[1][["_value"]].rename(columns={"_value": result_raw[1]["result"][0]}),
+                    result_raw[1][["_value"]].rename(
+                        columns={"_value": result_raw[1]["result"][0]}
+                    ),
                 ],
                 axis=1,
             ).set_index("_time")

--- a/tests/unit/services/test_database_prediction_job.py
+++ b/tests/unit/services/test_database_prediction_job.py
@@ -83,7 +83,7 @@ class TestPredictionJob(unittest.TestCase):
     def test_create_prediction_job_object_missing_attribute(self):
         pj_dict = self.prediction_job.copy()
         pj_dict.pop("forecast_type")
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(AttributeError):
             self.service._create_prediction_job_object(pj_dict)
 
     def test_create_prediction_job_object_without_train_components(self):


### PR DESCRIPTION
This PR fixes a problem that occurs (inconsistently) within the `get_load_sid` function, specifically within the postprocessing of the flux query result. The problem propagates itself to other parts of openstef-dbc, because `get_load_sid` function is used by many other functions, e.g. `get_load_pid` and `get_model_input`. 

The flux query, which this PR is about, returns two dataframes in a list. One of these dataframes contains the load and the other dataframe contains "the number of entries (`nEntries`)", which refers to the number of different system_id's for which the load is retrieved. The order of these dataframes within the returned list, is not always the same. The existing code was written under the assumption that the first dataframe in the list always is the dataframe with the load. However, sometimes the second dataframe contains the load. 

The consequence of this bug was that `nEntries`, which is constant for all timestamps, was mistaken for the load. So, our models would sometimes receive a constant (flatliner) load to train on and make (fallback) forecasts on, while in actuality the load was not constant.

The new code recognizes dynamically which of the two output dataframes in the list contains the load.