### PR TITLE
Add t_ahead 15 and 39

### DIFF
--- a/openstef_dbc/services/write.py
+++ b/openstef_dbc/services/write.py
@@ -175,7 +175,7 @@ class Write:
         influxtable = "prediction_tAheads"
 
         # specify desired t_aheads
-        desired_t_aheads = [0.0, 1.0, 4.0, 8.0, 24.0, 47.0, 50.0, 144.0]
+        desired_t_aheads = [0.0, 1.0, 4.0, 8.0, 15.0, 24.0, 39.0, 47.0, 50.0, 144.0]
 
         t_adf = forecast.copy()
 


### PR DESCRIPTION
T-ahead 47 appears to have an issue. Adding two more t-aheads to get more detailed insight.
![image](https://github.com/OpenSTEF/openstef-dbc/assets/37078892/7509ee28-6c66-4b94-831f-e720bb129c43)
