### PR TITLE
Update data_interface.py

### DIFF
--- a/.github/workflows/python-upload-package.yml
+++ b/.github/workflows/python-upload-package.yml
@@ -30,5 +30,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
     # Build and publish
-    - name: Build and publish
+    - name: Build
+      run: python setup.py sdist bdist_wheel
+    - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
+

--- a/.github/workflows/python-upload-package.yml
+++ b/.github/workflows/python-upload-package.yml
@@ -11,6 +11,10 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     steps:
     # Checkout
     - name: Checkout code
@@ -27,9 +31,4 @@ jobs:
         pip install setuptools wheel twine
     # Build and publish
     - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/openstef_dbc/data_interface.py
+++ b/openstef_dbc/data_interface.py
@@ -237,8 +237,6 @@ class _DataInterface(metaclass=Singleton):
             raise
 
     def exec_sql_write(self, statement: str, params: dict = None) -> None:
-        if params is None:
-            params = {}
         try:
             with self.mysql_engine.connect() as connection:
                 response = connection.execute(statement, params=params)

--- a/openstef_dbc/data_interface.py
+++ b/openstef_dbc/data_interface.py
@@ -222,8 +222,6 @@ class _DataInterface(metaclass=Singleton):
         return available
 
     def exec_sql_query(self, query: str, params: dict = None, **kwargs):
-        if params is None:
-            params = {}
         try:
             return pd.read_sql(query, self.mysql_engine, params=params, **kwargs)
         except sqlalchemy.exc.OperationalError as e:

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def read_long_description_from_readme():
 
 setup(
     name="openstef_dbc",
-    version="3.6.20a",
+    version="3.6.20a1",
     packages=find_packages(include=["openstef_dbc", "openstef_dbc.*"]),
     description="Database Connection for OpenSTEF",
     long_description=read_long_description_from_readme(),

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def read_long_description_from_readme():
 
 setup(
     name="openstef_dbc",
-    version="3.6.19",
+    version="3.6.20a",
     packages=find_packages(include=["openstef_dbc", "openstef_dbc.*"]),
     description="Database Connection for OpenSTEF",
     long_description=read_long_description_from_readme(),

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def read_long_description_from_readme():
 
 setup(
     name="openstef_dbc",
-    version="3.6.20a2",
+    version="3.6.21",
     packages=find_packages(include=["openstef_dbc", "openstef_dbc.*"]),
     description="Database Connection for OpenSTEF",
     long_description=read_long_description_from_readme(),

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def read_long_description_from_readme():
 
 setup(
     name="openstef_dbc",
-    version="3.6.20a1",
+    version="3.6.20a2",
     packages=find_packages(include=["openstef_dbc", "openstef_dbc.*"]),
     description="Database Connection for OpenSTEF",
     long_description=read_long_description_from_readme(),


### PR DESCRIPTION
Should fix:
![image](https://github.com/OpenSTEF/openstef-dbc/assets/18208480/69dfad5f-1630-477e-bea3-669033b201c0)

Replacing None with empty dict is not needed and causes issues, pd.read_sql can deal with params=None. 

I did not test if this actually resolves the issue. Maybe we can make a pre-release, include that in a fix-branch of icarus-forecasts and see if that resolves the issue?

Update; the pre-release works:
![image](https://github.com/OpenSTEF/openstef-dbc/assets/18208480/64d5b87b-6571-49e6-bee2-e15f961b3afc)
Bumping it to a proper version an releasing.