### PR TITLE
Enabling multiple weatherforecastlocations selection

### DIFF
--- a/openstef_dbc/services/weather.py
+++ b/openstef_dbc/services/weather.py
@@ -270,7 +270,7 @@ class Weather:
 
         location_name = self._get_nearest_weather_locations(
             location=location, country=country, number_locations=number_locations
-        ).to_list()
+        )
 
         # Make a list of the source and weatherparams.
         # Like this, it also works if source is a string instead of multiple values
@@ -303,7 +303,7 @@ class Weather:
         # Initialise strings for the querying influx, it is not possible to parameterize this string
         weather_params_str = '" or r._field == "'.join(weatherparams)
         weather_models_str = '" or r.source == "'.join(source)
-        weather_location_name_str = '" or r.input_city == "'.join(location_name)
+        weather_location_name_str = '" or r.input_city == "'.join(location_name.to_list())
 
         # Create the query
         query = f"""
@@ -359,6 +359,13 @@ class Weather:
 
         if number_locations == 1:
             result = result.drop(columns="input_city")
+        else :
+            # Adding distance information en km
+            result = (
+                result.reset_index().
+                merge(location_name.reset_index(), how = "left", on="input_city")
+                .set_index("datetime")
+                )
 
         return result
 

--- a/openstef_dbc/services/weather.py
+++ b/openstef_dbc/services/weather.py
@@ -271,7 +271,9 @@ class Weather:
 
         datetime_start -= timedelta(hours=1)
 
-        location_name = self._get_nearest_weather_location(location=location, country=country, k=k)
+        location_name = self._get_nearest_weather_location(
+            location=location, country=country, k=k
+        )
 
         # Make a list of the source and weatherparams.
         # Like this, it also works if source is a string instead of multiple values
@@ -341,26 +343,30 @@ class Weather:
             result = self._combine_weather_sources(result)
 
         # Interpolate if nescesarry by input_city and source
-        result = result.groupby(['input_city'])\
-                .resample(resolution)\
-                    .interpolate(limit=11)\
-                        .drop(columns = ['input_city'])\
-                            .reset_index(['input_city'])
-        
-        #result = result.resample(resolution).interpolate(limit=11)
+        result = (
+            result.groupby(["input_city"])
+            .resample(resolution)
+            .interpolate(limit=11)
+            .drop(columns=["input_city"])
+            .reset_index(["input_city"])
+        )
+
+        # result = result.resample(resolution).interpolate(limit=11)
 
         # Shift radiation by 30 minutes if resolution allows it
         if "radiation" in result.columns:
             shift_delta = -timedelta(minutes=30)
             if shift_delta % pd.Timedelta(resolution) == timedelta(0):
-                result["radiation"] = result.groupby(['input_city'])["radiation"].shift(1, shift_delta)
+                result["radiation"] = result.groupby(["input_city"])["radiation"].shift(
+                    1, shift_delta
+                )
 
         # Drop extra rows not neccesary
         result = result[result.index >= datetime_start_original]
 
-        if k==1:
-            result=result.drop(columns="input_city")
-        
+        if k == 1:
+            result = result.drop(columns="input_city")
+
         return result
 
     def get_datetime_last_stored_knmi_weatherdata(self) -> datetime:

--- a/openstef_dbc/services/weather.py
+++ b/openstef_dbc/services/weather.py
@@ -303,7 +303,9 @@ class Weather:
         # Initialise strings for the querying influx, it is not possible to parameterize this string
         weather_params_str = '" or r._field == "'.join(weatherparams)
         weather_models_str = '" or r.source == "'.join(source)
-        weather_location_name_str = '" or r.input_city == "'.join(location_name.to_list())
+        weather_location_name_str = '" or r.input_city == "'.join(
+            location_name.to_list()
+        )
 
         # Create the query
         query = f"""
@@ -359,13 +361,13 @@ class Weather:
 
         if number_locations == 1:
             result = result.drop(columns="input_city")
-        else :
+        else:
             # Adding distance information en km
             result = (
-                result.reset_index().
-                merge(location_name.reset_index(), how = "left", on="input_city")
+                result.reset_index()
+                .merge(location_name.reset_index(), how="left", on="input_city")
                 .set_index("datetime")
-                )
+            )
 
         return result
 

--- a/openstef_dbc/services/weather.py
+++ b/openstef_dbc/services/weather.py
@@ -55,6 +55,7 @@ class Weather:
         location: Union[Tuple[float, float], str],
         country: str = "NL",
         threshold: float = 150.0,
+        k: int = 1,
     ) -> str:
         """Find the nearest weather forecast location.
 
@@ -68,6 +69,7 @@ class Weather:
             location (str, tuple): Name of the location/city or coordinates (lat, lon).
             country (str): Country code (2-letter: ISO 3166-1).
             threshold (int): Maximum distance [km] before a warning is generated.
+            k (int): number of weather locations desired
 
         Returns:
             str: The name of the weather forecast location.
@@ -103,12 +105,12 @@ class Weather:
 
         distances = distances.set_index("distance")
 
-        nearest_location = distances["input_city"][distances.index.min()]
+        nearest_location = distances["input_city"].sort_index()[0:k]
 
         # Find closest weather location
         if distances.index.min() < threshold:
             if isinstance(nearest_location, pd.Series):
-                return nearest_location.reset_index(drop=True)[0]
+                return nearest_location.reset_index(drop=True)
             else:
                 return nearest_location
 

--- a/tests/unit/data/multiple_locations_weatherdata_nomissing_test_data.csv
+++ b/tests/unit/data/multiple_locations_weatherdata_nomissing_test_data.csv
@@ -1,0 +1,17 @@
+;_time;_value;_field;_measurement;input_city;source
+0;2022-01-01 00:00:00+00:00;3.6144495010375977;windspeed;weather;Amsterdam;harm_arome
+20;2022-01-01 00:00:00+00:00;3.5552268028259277;windspeed;weather;Rotterdam;harm_arome
+10;2022-01-01 01:00:00+00:00;6.942558765411377;windspeed;weather;Amsterdam;harm_arome
+30;2022-01-01 01:00:00+00:00;7.5660576820373535;windspeed;weather;Rotterdam;harm_arome
+1;2022-01-01 02:00:00+00:00;1.1569029092788696;windspeed;weather;Amsterdam;harm_arome
+21;2022-01-01 02:00:00+00:00;1.4971693754196167;windspeed;weather;Rotterdam;harm_arome
+11;2022-01-01 03:00:00+00:00;0.7596001029014587;windspeed;weather;Amsterdam;harm_arome
+31;2022-01-01 03:00:00+00:00;1.4958148002624512;windspeed;weather;Rotterdam;harm_arome
+2;2022-01-01 04:00:00+00:00;0.625495970249176;windspeed;weather;Amsterdam;harm_arome
+22;2022-01-01 04:00:00+00:00;0.1717752367258072;windspeed;weather;Rotterdam;harm_arome
+12;2022-01-01 05:00:00+00:00;0.9497405290603638;windspeed;weather;Amsterdam;harm_arome
+32;2022-01-01 05:00:00+00:00;1.7051881551742554;windspeed;weather;Rotterdam;harm_arome
+3;2022-01-01 06:00:00+00:00;0.5791314840316772;windspeed;weather;Amsterdam;harm_arome
+23;2022-01-01 06:00:00+00:00;0.4893384575843811;windspeed;weather;Rotterdam;harm_arome
+13;2022-01-01 07:00:00+00:00;2.078191041946411;windspeed;weather;Amsterdam;harm_arome
+33;2022-01-01 07:00:00+00:00;3.0576376914978027;windspeed;weather;Rotterdam;harm_arome

--- a/tests/unit/services/test_get_nearest_weather_locations.py
+++ b/tests/unit/services/test_get_nearest_weather_locations.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2017-2022 Contributors to the OpenSTEF project <korte.termijn.prognoses@alliander.com>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+from openstef_dbc.services.weather import Weather
+
+
+
+@patch("openstef_dbc.data_interface._DataInterface.get_instance")
+class TestGetNearestWeatherLocations(unittest.TestCase):
+    def test(self, data_interface_get_instance_mock):
+
+        # Mock other functions
+        weather = Weather()
+        cities = [
+            {'city': 'A', 'lat': 42.3, 'lon': 2.2, 'country': 'FR'},
+            {'city': 'B', 'lat': 43.3, 'lon': 2.6, 'country': 'FR'},
+            {'city': 'C', 'lat': 42.5, 'lon': 2.6, 'country': 'FR'},
+            {'city': 'D', 'lat': 42.3, 'lon': 2.6, 'country': 'FR'},
+            {'city': 'E', 'lat': 42.3, 'lon': 2.8, 'country': 'FR'},
+        ]
+        weather.get_weather_forecast_locations = lambda country, active: cities
+
+        # Test one location with equal distance (D and E)
+        df_check = weather._get_nearest_weather_locations(
+            location=[42.3, 2.7], country="FR", number_locations=1
+        )
+        # Check for correct results
+        expected_response = pd.Series('D',index=[8.2])
+        expected_response.name = 'input_city'
+        self.assertTrue(df_check.equals(expected_response))
+
+        # Test two locations
+        df_check = weather._get_nearest_weather_locations(
+            location=[42.3, 2.7], country="FR", number_locations=2
+        )
+        # Check for correct results
+        expected_response = pd.Series(['D','E'], index=[8.2,8.2])
+        expected_response.name = 'input_city'
+
+        self.assertTrue(df_check.equals(expected_response))
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/unit/services/test_get_nearest_weather_locations.py
+++ b/tests/unit/services/test_get_nearest_weather_locations.py
@@ -13,7 +13,6 @@ from openstef_dbc.services.weather import Weather
 @patch("openstef_dbc.data_interface._DataInterface.get_instance")
 class TestGetNearestWeatherLocations(unittest.TestCase):
     def test(self, data_interface_get_instance_mock):
-
         # Mock other functions
         weather = Weather()
         cities = [

--- a/tests/unit/services/test_radiation_shift.py
+++ b/tests/unit/services/test_radiation_shift.py
@@ -35,7 +35,7 @@ class TestRadiationShift(unittest.TestCase):
 
         # Mock other functions
         weather = Weather()
-        weather._get_nearest_weather_location = lambda x, y: x
+        weather._get_nearest_weather_locations = lambda x, y: x
         weather._combine_weather_sources = lambda x: x
 
         # Run function

--- a/tests/unit/services/test_weather.py
+++ b/tests/unit/services/test_weather.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
+import numpy as np
 from openstef_dbc.services.weather import Weather
+from openstef_dbc.data_interface import _DataInterface
 from tests.unit.utils.base import BaseTestCase
 
 DATA_FOLDER = Path(__file__).absolute().parent.parent / "data"
@@ -47,14 +49,29 @@ combined_weatherdata_DSN = pd.read_csv(
     parse_dates=["datetime"],
 )
 
+multiple_location_weatherdata = pd.read_csv(
+    DATA_FOLDER / "multiple_locations_weatherdata_nomissing_test_data.csv",
+    sep=";",
+    index_col=0,
+    parse_dates=["_time"],
+)
 
-@patch("openstef_dbc.services.weather._DataInterface", MagicMock())
+locations = [
+    {'city': 'Rotterdam', 'lat': 51.926517, 'lon': 4.462456, 'country': 'NL'},
+    {'city': 'Amsterdam', 'lat': 52.377956, 'lon': 4.897070, 'country': 'NL'}
+]
+
 @patch("openstef_dbc.services.weather.Write", MagicMock())
-class TestWeather(BaseTestCase):
-    def test_combine_weather_sources_fill_nan_values(self):
-        """Data: dataframe contains weather data of multiple sources for same timpestamp with nan-values
 
-        Expected: dataframe without duplicate timestamps containing data from multiple data sources without nan-values
+
+class TestWeather(BaseTestCase):
+
+    @patch("openstef_dbc.services.weather._DataInterface", MagicMock())
+
+    def test_combine_weather_sources_fill_nan_values(self):
+        """Data: dataframe contains weather data of multiple sources for same timpestamp with np.nan-values
+
+        Expected: dataframe without duplicate timestamps containing data from multiple data sources without np.nan-values
         """
         database = Weather()
         response = database._combine_weather_sources(result=noncombined_weatherdata)
@@ -62,7 +79,7 @@ class TestWeather(BaseTestCase):
         self.assertDataframeEqual(expected_response, response)
 
     def test_no_nan_values(self):
-        """Data: dataframe contains weather data of multiple sources for same timpestamp without nan-values
+        """Data: dataframe contains weather data of multiple sources for same timpestamp without np.nan-values
 
         Expected: dataframe containing data only from preferred data source. No duplicate timestamps
         """
@@ -77,9 +94,9 @@ class TestWeather(BaseTestCase):
         "TO FIX: assert fails pressure column is of type object (str) in response"
     )
     def test_different_source_order(self):
-        """Data: dataframe contains weather data of multiple sources for same timpestamp with nan-values
+        """Data: dataframe contains weather data of multiple sources for same timpestamp with np.nan-values
 
-        Expected: dataframe without duplicate timestamps containing data from mostly DSN data source without nan-values
+        Expected: dataframe without duplicate timestamps containing data from mostly DSN data source without np.nan-values
         """
         database = Weather()
         response = database._combine_weather_sources(
@@ -99,6 +116,99 @@ class TestWeather(BaseTestCase):
         expected_response = combined_weatherdata
         self.assertDataframeEqual(expected_response, response)
 
+    @patch("openstef_dbc.services.weather._DataInterface")
 
-if __name__ == "__main__":
-    unittest.main()
+    def test_get_multiple_location_weather_data(self, MockDataInterface):
+
+        """Data: dataframe contains weather data of multiple 
+        locations for same timpestamp with np.nan-values
+
+        Expected: return same dataframe
+        """
+
+        datetime_start = pd.to_datetime('2022-01-01 00:00:00+00:00')
+        datetime_end = pd.to_datetime('2022-01-01 02:00:00+00:00')
+       
+        mock_instance = MagicMock()
+        MockDataInterface.get_instance.return_value = mock_instance
+        mock_instance.exec_influx_query.return_value = multiple_location_weatherdata 
+
+        weather = Weather()
+        # Mocking get_weather_forecast_locations
+        weather.get_weather_forecast_locations = lambda country, active: locations
+
+        nearest_location = weather._get_nearest_weather_locations(
+            location=[52,4.7],
+            number_locations=2
+        ).to_list()
+
+        query = f"input_city in {nearest_location} & _time > '{datetime_start}+00:00' & _time <= '{datetime_end}+00:00' & _field == 'windspeed'"
+        mock_instance.exec_influx_query.return_value = multiple_location_weatherdata.query(query)
+
+        response = weather.get_weather_data(
+            location=[52,4.7],
+            weatherparams="windspeed",
+            datetime_start= datetime_start,
+            datetime_end= datetime_end,
+            number_locations=2,
+            resolution = "30min")
+        response.windspeed = np.round(response.windspeed,1)
+
+        expected_response = pd.DataFrame({
+            'input_city': ['Amsterdam', 'Amsterdam', 'Amsterdam', 'Rotterdam', 'Rotterdam', 'Rotterdam'],
+            'source': ['harm_arome', np.nan, 'harm_arome', 'harm_arome', np.nan, 'harm_arome'],
+            'windspeed': [6.9, 4.0, 1.2, 7.6, 4.5, 1.5],
+            'distance': [44.2, 44.2, 44.2, 18.3, 18.3, 18.3],
+        },index = np.tile(pd.date_range(start="2022-01-01 01:00:00+00:00",end="2022-01-01 02:00:00+00:00",freq = "30min"),2))
+        expected_response.index.name = 'datetime'
+               
+        self.assertTrue(response.equals(expected_response))
+
+    @patch("openstef_dbc.services.weather._DataInterface")
+
+    def test_get_single_location_weather_data(self, MockDataInterface):
+
+        """Data: dataframe contains weather data of multiple 
+        locations for same timpestamp with np.nan-values
+
+        Expected: return same dataframe
+        """
+
+        datetime_start = pd.to_datetime('2022-01-01 00:00:00+00:00')
+        datetime_end = pd.to_datetime('2022-01-01 02:00:00+00:00')
+       
+        mock_instance = MagicMock()
+        MockDataInterface.get_instance.return_value = mock_instance
+        mock_instance.exec_influx_query.return_value = multiple_location_weatherdata 
+
+        weather = Weather()
+        # Mocking get_weather_forecast_locations
+        weather.get_weather_forecast_locations = lambda country, active: locations
+
+        nearest_location = weather._get_nearest_weather_locations(
+            location=[52,4.7],
+            number_locations=1
+        ).to_list()
+
+        query = f"input_city in {nearest_location} & _time > '{datetime_start}+00:00' & _time <= '{datetime_end}+00:00' & _field == 'windspeed'"
+        mock_instance.exec_influx_query.return_value = multiple_location_weatherdata.query(query)
+
+        response = weather.get_weather_data(
+            location=[52,4.7],
+            weatherparams="windspeed",
+            datetime_start= datetime_start,
+            datetime_end= datetime_end,
+            number_locations=1,
+            resolution = "30min")
+        response.windspeed = np.round(response.windspeed,1)
+
+        expected_response = pd.DataFrame({
+            'source': ['harm_arome', np.nan, 'harm_arome'],
+            'windspeed': [7.6, 4.5, 1.5],
+        },index = pd.date_range(start="2022-01-01 01:00:00+00:00",end="2022-01-01 02:00:00+00:00",freq = "30min"))
+        expected_response.index.name = 'datetime'
+               
+        self.assertTrue(response.equals(expected_response))
+
+
+if __name__ == "__main__":    unittest.main()

--- a/tests/unit/services/test_weather.py
+++ b/tests/unit/services/test_weather.py
@@ -57,17 +57,14 @@ multiple_location_weatherdata = pd.read_csv(
 )
 
 locations = [
-    {'city': 'Rotterdam', 'lat': 51.926517, 'lon': 4.462456, 'country': 'NL'},
-    {'city': 'Amsterdam', 'lat': 52.377956, 'lon': 4.897070, 'country': 'NL'}
+    {"city": "Rotterdam", "lat": 51.926517, "lon": 4.462456, "country": "NL"},
+    {"city": "Amsterdam", "lat": 52.377956, "lon": 4.897070, "country": "NL"},
 ]
 
+
 @patch("openstef_dbc.services.weather.Write", MagicMock())
-
-
 class TestWeather(BaseTestCase):
-
     @patch("openstef_dbc.services.weather._DataInterface", MagicMock())
-
     def test_combine_weather_sources_fill_nan_values(self):
         """Data: dataframe contains weather data of multiple sources for same timpestamp with np.nan-values
 
@@ -117,98 +114,127 @@ class TestWeather(BaseTestCase):
         self.assertDataframeEqual(expected_response, response)
 
     @patch("openstef_dbc.services.weather._DataInterface")
-
     def test_get_multiple_location_weather_data(self, MockDataInterface):
-
-        """Data: dataframe contains weather data of multiple 
+        """Data: dataframe contains weather data of multiple
         locations for same timpestamp with np.nan-values
 
         Expected: return same dataframe
         """
 
-        datetime_start = pd.to_datetime('2022-01-01 00:00:00+00:00')
-        datetime_end = pd.to_datetime('2022-01-01 02:00:00+00:00')
-       
+        datetime_start = pd.to_datetime("2022-01-01 00:00:00+00:00")
+        datetime_end = pd.to_datetime("2022-01-01 02:00:00+00:00")
+
         mock_instance = MagicMock()
         MockDataInterface.get_instance.return_value = mock_instance
-        mock_instance.exec_influx_query.return_value = multiple_location_weatherdata 
 
         weather = Weather()
-        # Mocking get_weather_forecast_locations
+        # Mocking influx query et get_weather_forecast_locations
         weather.get_weather_forecast_locations = lambda country, active: locations
-
         nearest_location = weather._get_nearest_weather_locations(
-            location=[52,4.7],
-            number_locations=2
+            location=[52, 4.7], number_locations=2
         ).to_list()
 
         query = f"input_city in {nearest_location} & _time > '{datetime_start}+00:00' & _time <= '{datetime_end}+00:00' & _field == 'windspeed'"
-        mock_instance.exec_influx_query.return_value = multiple_location_weatherdata.query(query)
+        mock_instance.exec_influx_query.return_value = (
+            multiple_location_weatherdata.query(query)
+        )
 
         response = weather.get_weather_data(
-            location=[52,4.7],
+            location=[52, 4.7],
             weatherparams="windspeed",
-            datetime_start= datetime_start,
-            datetime_end= datetime_end,
+            datetime_start=datetime_start,
+            datetime_end=datetime_end,
             number_locations=2,
-            resolution = "30min")
-        response.windspeed = np.round(response.windspeed,1)
+            resolution="30min",
+        )
+        response.windspeed = np.round(response.windspeed, 1)
 
-        expected_response = pd.DataFrame({
-            'input_city': ['Amsterdam', 'Amsterdam', 'Amsterdam', 'Rotterdam', 'Rotterdam', 'Rotterdam'],
-            'source': ['harm_arome', np.nan, 'harm_arome', 'harm_arome', np.nan, 'harm_arome'],
-            'windspeed': [6.9, 4.0, 1.2, 7.6, 4.5, 1.5],
-            'distance': [44.2, 44.2, 44.2, 18.3, 18.3, 18.3],
-        },index = np.tile(pd.date_range(start="2022-01-01 01:00:00+00:00",end="2022-01-01 02:00:00+00:00",freq = "30min"),2))
-        expected_response.index.name = 'datetime'
-               
+        expected_response = pd.DataFrame(
+            {
+                "input_city": [
+                    "Amsterdam",
+                    "Amsterdam",
+                    "Amsterdam",
+                    "Rotterdam",
+                    "Rotterdam",
+                    "Rotterdam",
+                ],
+                "source": [
+                    "harm_arome",
+                    np.nan,
+                    "harm_arome",
+                    "harm_arome",
+                    np.nan,
+                    "harm_arome",
+                ],
+                "windspeed": [6.9, 4.0, 1.2, 7.6, 4.5, 1.5],
+                "distance": [44.2, 44.2, 44.2, 18.3, 18.3, 18.3],
+            },
+            index=np.tile(
+                pd.date_range(
+                    start="2022-01-01 01:00:00+00:00",
+                    end="2022-01-01 02:00:00+00:00",
+                    freq="30min",
+                ),
+                2,
+            ),
+        )
+        expected_response.index.name = "datetime"
+
         self.assertTrue(response.equals(expected_response))
 
     @patch("openstef_dbc.services.weather._DataInterface")
-
     def test_get_single_location_weather_data(self, MockDataInterface):
-
-        """Data: dataframe contains weather data of multiple 
+        """Data: dataframe contains weather data of multiple
         locations for same timpestamp with np.nan-values
 
         Expected: return same dataframe
         """
 
-        datetime_start = pd.to_datetime('2022-01-01 00:00:00+00:00')
-        datetime_end = pd.to_datetime('2022-01-01 02:00:00+00:00')
-       
+        datetime_start = pd.to_datetime("2022-01-01 00:00:00+00:00")
+        datetime_end = pd.to_datetime("2022-01-01 02:00:00+00:00")
+
         mock_instance = MagicMock()
         MockDataInterface.get_instance.return_value = mock_instance
-        mock_instance.exec_influx_query.return_value = multiple_location_weatherdata 
 
         weather = Weather()
-        # Mocking get_weather_forecast_locations
+        # Mocking influx query and get_weather_forecast_locations
         weather.get_weather_forecast_locations = lambda country, active: locations
 
         nearest_location = weather._get_nearest_weather_locations(
-            location=[52,4.7],
-            number_locations=1
+            location=[52, 4.7], number_locations=1
         ).to_list()
 
         query = f"input_city in {nearest_location} & _time > '{datetime_start}+00:00' & _time <= '{datetime_end}+00:00' & _field == 'windspeed'"
-        mock_instance.exec_influx_query.return_value = multiple_location_weatherdata.query(query)
+        mock_instance.exec_influx_query.return_value = (
+            multiple_location_weatherdata.query(query)
+        )
 
         response = weather.get_weather_data(
-            location=[52,4.7],
+            location=[52, 4.7],
             weatherparams="windspeed",
-            datetime_start= datetime_start,
-            datetime_end= datetime_end,
+            datetime_start=datetime_start,
+            datetime_end=datetime_end,
             number_locations=1,
-            resolution = "30min")
-        response.windspeed = np.round(response.windspeed,1)
+            resolution="30min",
+        )
+        response.windspeed = np.round(response.windspeed, 1)
 
-        expected_response = pd.DataFrame({
-            'source': ['harm_arome', np.nan, 'harm_arome'],
-            'windspeed': [7.6, 4.5, 1.5],
-        },index = pd.date_range(start="2022-01-01 01:00:00+00:00",end="2022-01-01 02:00:00+00:00",freq = "30min"))
-        expected_response.index.name = 'datetime'
-               
+        expected_response = pd.DataFrame(
+            {
+                "source": ["harm_arome", np.nan, "harm_arome"],
+                "windspeed": [7.6, 4.5, 1.5],
+            },
+            index=pd.date_range(
+                start="2022-01-01 01:00:00+00:00",
+                end="2022-01-01 02:00:00+00:00",
+                freq="30min",
+            ),
+        )
+        expected_response.index.name = "datetime"
+
         self.assertTrue(response.equals(expected_response))
 
 
-if __name__ == "__main__":    unittest.main()
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The evolution enables multiple weatherforecastlocations selection.

Default is one weatherforecastlocation (the nearest) so it does not impact the original behaviour of the code.