### PR TITLE
fix(KTP-1106): Fixed issue where mysql connection might break when fetching result due to improper connection closing.

### DIFF
--- a/openstef_dbc/data_interface.py
+++ b/openstef_dbc/data_interface.py
@@ -223,13 +223,12 @@ class _DataInterface(metaclass=Singleton):
 
     def exec_sql_query(self, query: str, params: dict = None):
         try:
-            connection = self.mysql_engine.connect()
-            if params is None:
-                params = {}
-            cursor = connection.execute(query, **params)
-            connection.close()
-            if cursor.cursor is not None:
-                return pd.DataFrame(cursor.fetchall())
+            with self.mysql_engine.connect() as connection:
+                if params is None:
+                    params = {}
+                cursor = connection.execute(query, **params)
+                if cursor.cursor is not None:
+                    return pd.DataFrame(cursor.fetchall())
         except sqlalchemy.exc.OperationalError as e:
             self.logger.error("Lost connection to MySQL database", exc_info=e)
             raise


### PR DESCRIPTION
In production we see sometimes this error:

```
13:16:31.527
kubernetes.container_logs
           ^^^^^^^^^^^^^^^^^^^
13:16:31.527
kubernetes.container_logs
  File "/app/routers/api/v1/measurements/controller.py", line 61, in _check_api_key
13:16:31.527
kubernetes.container_logs
    api_key = self.repository.get_api_key_for_system(sid=sid)
13:16:31.527
kubernetes.container_logs
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
13:16:31.527
kubernetes.container_logs
  File "/.venv/lib/python3.11/site-packages/openstef_dbc/services/systems.py", line 144, in get_api_key_for_system
13:16:31.527
kubernetes.container_logs
    result = _DataInterface.get_instance().exec_sql_query(query, bind_params)
13:16:31.527
kubernetes.container_logs
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
13:16:31.527
kubernetes.container_logs
  File "/.venv/lib/python3.11/site-packages/openstef_dbc/data_interface.py", line 228, in exec_sql_query
13:16:31.527
kubernetes.container_logs
    return pd.read_sql(query, self.mysql_engine, params=params, **kwargs)
13:16:31.527
kubernetes.container_logs
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
13:16:31.527
kubernetes.container_logs
  File "/.venv/lib/python3.11/site-packages/pandas/io/sql.py", line 706, in read_sql
13:16:31.527
kubernetes.container_logs
    return pandas_sql.read_query(
13:16:31.527
kubernetes.container_logs
           ^^^^^^^^^^^^^^^^^^^^^^
13:16:31.527
kubernetes.container_logs
  File "/.venv/lib/python3.11/site-packages/pandas/io/sql.py", line 2738, in read_query
13:16:31.527
kubernetes.container_logs
    cursor = self.execute(sql, params)
13:16:31.527
kubernetes.container_logs
             ^^^^^^^^^^^^^^^^^^^^^^^^^
13:16:31.527
kubernetes.container_logs
  File "/.venv/lib/python3.11/site-packages/pandas/io/sql.py", line 2672, in execute
13:16:31.527
kubernetes.container_logs
    cur = self.con.cursor()
13:16:31.527
kubernetes.container_logs
          ^^^^^^^^^^^^^^^^^
13:16:31.527
kubernetes.container_logs
  File "/.venv/lib/python3.11/site-packages/sqlalchemy/pool/base.py", line 1133, in cursor
13:16:31.527
kubernetes.container_logs
    return self.dbapi_connection.cursor(*args, **kwargs)
13:16:31.527
kubernetes.container_logs
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
13:16:31.527
kubernetes.container_logs
  File "/.venv/lib/python3.11/site-packages/mysql/connector/connection.py", line 1410, in cursor
13:16:31.527
kubernetes.container_logs
    raise OperationalError("MySQL Connection not available")
13:16:31.527
kubernetes.container_logs
mysql.connector.errors.OperationalError: MySQL Connection not available
```

MySQL Connection not available seems to be indicative that query is executed once connection is closed. Looking at the code it seems that connection is being closed before the result is being fetched. Since `.fetchall` requires connection it's weird that this works at all.