### PR TITLE
New influxDB measurement to store weather forecasts with tAhead

### DIFF
--- a/openstef_dbc/services/weather.py
+++ b/openstef_dbc/services/weather.py
@@ -370,7 +370,9 @@ class Weather:
         if "radiation" in result.columns:
             shift_delta = -timedelta(minutes=30)
             if shift_delta % pd.Timedelta(resolution) == timedelta(0):
-                result["radiation"] = result.groupby(grouping_indices)["radiation"].shift(1, shift_delta)
+                result["radiation"] = result.groupby(grouping_indices)[
+                    "radiation"
+                ].shift(1, shift_delta)
 
         # Drop extra rows not neccesary
         result = result[result.index >= datetime_start_original]

--- a/openstef_dbc/services/weather.py
+++ b/openstef_dbc/services/weather.py
@@ -232,12 +232,13 @@ class Weather:
         self,
         location: Union[Tuple[float, float], str],
         weatherparams: List[str],
-        datetime_start: datetime = None,
-        datetime_end: datetime = None,
+        datetime_start: datetime = datetime.utcnow() - timedelta(days=14),
+        datetime_end: datetime = datetime.utcnow() + timedelta(days=2),
         source: Union[List[str], str] = "optimum",
         resolution: str = "15min",
         country: str = "NL",
         number_locations: int = 1,
+        type: chr = "smallest_tAhead",
     ) -> pd.DataFrame:
         """Get weather data from database.
 
@@ -259,6 +260,7 @@ class Weather:
             resolution (str): Time resolution of the returned data, default: "15T"
             country (str): Country code (2-letter: ISO 3166-1). e.g. NL
             number_locations (int): number of weather locations desired
+            type (chr) : type of weather forecast (smallest_tAhead of multiple_tAheads)
         Returns:
             pd.DataFrame: The most recent weather prediction
 
@@ -268,16 +270,6 @@ class Weather:
                                   weatherParams=["clouds", "radiation"], source='optimum')
             print(df.head())
         """
-
-        if datetime_start is None:
-            datetime_start = datetime.utcnow() - timedelta(days=14)
-
-        datetime_start = pd.to_datetime(datetime_start)
-
-        if datetime_end is None:
-            datetime_end = datetime.utcnow() + timedelta(days=2)
-
-        datetime_end = pd.to_datetime(datetime_end)
 
         # Convert to UTC and remove UTC as note
         if datetime_start.tz is not None:
@@ -329,12 +321,22 @@ class Weather:
         weather_location_name_str = '" or r.input_city == "'.join(
             location_name.to_list()
         )
+        
+        if type == "smallest_tAhead":
+            weather_measurement_str = 'weather'
+            influx_indices = ["source", "input_city"]
+            grouping_indices = ["source", "input_city"]
+        elif type == "multiple_tAheads":
+            weather_measurement_str = 'weather_tAhead'
+            influx_indices = ["source", "input_city", "tAhead"]
+            grouping_indices = ["source", "input_city", "created"]
+        
 
         # Create the query
         query = f"""
             from(bucket: "forecast_latest/autogen") 
                 |> range(start: {bind_params["_start"].strftime('%Y-%m-%dT%H:%M:%SZ')}, stop: {bind_params["_stop"].strftime('%Y-%m-%dT%H:%M:%SZ')}) 
-                |> filter(fn: (r) => r._measurement == "weather" and (r._field == "{weather_params_str}") and (r.source == "{weather_models_str}") and (r.input_city == "{weather_location_name_str}"))
+                |> filter(fn: (r) => r._measurement == "{weather_measurement_str}" and (r._field == "{weather_params_str}") and (r.source == "{weather_models_str}") and (r.input_city == "{weather_location_name_str}"))
         """
 
         # Execute Query
@@ -346,7 +348,7 @@ class Weather:
 
         # Check if response is empty
         if not result.empty:
-            result = parse_influx_result(result, ["source", "input_city"])
+            result = parse_influx_result(result, influx_indices)
         else:
             self.logger.warning("No weatherdata found. Returning empty dataframe")
             return pd.DataFrame(
@@ -361,185 +363,28 @@ class Weather:
         if combine_sources:
             self.logger.info("Combining sources into single dataframe")
             result = self._combine_weather_sources(result)
-
-        # Interpolate if nescesarry by input_city and source
-        result = (
-            result.groupby(["input_city"])
-            .resample(resolution)
-            .interpolate(limit=11)
-            .drop(columns=["input_city"])
-            .reset_index(["input_city"])
-        )
-
-        # Shift radiation by 30 minutes if resolution allows it
-        if "radiation" in result.columns:
-            shift_delta = -timedelta(minutes=30)
-            if shift_delta % pd.Timedelta(resolution) == timedelta(0):
-                result["radiation"] = result.groupby(["input_city"])["radiation"].shift(
-                    1, shift_delta
-                )
-
-        # Drop extra rows not neccesary
-        result = result[result.index >= datetime_start_original]
-
-        if number_locations == 1:
-            result = result.drop(columns="input_city")
-        else:
-            # Adding distance information en km
-            result = (
-                result.reset_index()
-                .merge(location_name.reset_index(), how="left", on="input_city")
-                .set_index("datetime")
-            )
-
-        return result
-
-    def get_weather_tAhead_data(
-        self,
-        location: Union[Tuple[float, float], str],
-        weatherparams: List[str],
-        datetime_start: datetime = datetime.utcnow() - timedelta(days=14),
-        datetime_end: datetime = datetime.utcnow() + timedelta(days=2),
-        source: Union[List[str], str] = "optimum",
-        resolution: str = "15min",
-        country: str = "NL",
-        number_locations: int = 1,
-    ) -> pd.DataFrame:
-        """Get weather data from database.
-
-        Additionally, weatherdata from several sources is combined to a single forecast.
-        When the source equals "optimum", data from harmonie is preferred,
-            completed by data from harm_arome and DSN
-
-        Args:
-            location (str): Location. Should be in the stored locations. e.g. Volkel
-            weatherparams  (str or list of str): weatherparams that are required.
-                Params include: ["clouds", "radiation", "temp", "winddeg", "windspeed", "windspeed_100m", "pressure",
-                "humidity", "rain", 'mxlD', 'snowDepth', 'clearSky_ulf', 'clearSky_dlf', 'ssrunoff']
-            datetime_start (datetime) : start date time. Default: 14 days ago
-            datetime_end (datetime): end date time. Default: now + 2 days.
-            source (str or list of str): which weather models should be used.
-                Options: "OWM", "DSN", "WUN", "harmonie", "harm_arome", "harm_arome_fallback", "icon", "optimum",
-                Default: 'optimum'. This combines harmonie, harm_arome, icon and DSN,
-                taking the (heuristicly) best available source for each moment in time
-            resolution (str): Time resolution of the returned data, default: "15T"
-            country (str): Country code (2-letter: ISO 3166-1). e.g. NL
-            number_locations (int): number of weather locations desired
-        Returns:
-            pd.DataFrame: The most recent weather prediction
-
-        Example:
-            client = influxdb.DataFrameClient()
-            df = QueryWeatherData(client, location='Volkel',
-                                  weatherParams=["clouds", "radiation"], source='optimum')
-            print(df.head())
-        """
-
-        datetime_start = pd.to_datetime(datetime_start)
-        # Get data from an hour earlier to correct for radiation shift later
-        datetime_start_original = datetime_start
-        datetime_end = pd.to_datetime(datetime_end)
-
-        # Convert to UTC and remove UTC as note
-        if datetime_start.tz is not None:
-            datetime_start = datetime_start.tz_convert("UTC").tz_localize(None)
-
-        if datetime_end.tz is not None:
-            datetime_end = datetime_end.tz_convert("UTC").tz_localize(None)
-
-        datetime_start -= timedelta(hours=1)
-
-        location_name = self._get_nearest_weather_locations(
-            location=location, country=country, number_locations=number_locations
-        )
-
-        # Make a list of the source and weatherparams.
-        # Like this, it also works if source is a string instead of multiple values
-        if isinstance(source, str):
-            source = [source]
-        if isinstance(weatherparams, str):
-            weatherparams = [weatherparams]
-
-        # Try to get the data from influx.
-        if "optimum" in source:
-            # so the query return all
-            source = [
-                "harm_arome",
-                "harm_arome_fallback",
-                "GFS_50",
-                "harmonie",
-                "icon",
-                "DSN",
-            ]
-            combine_sources = True
-        else:
-            combine_sources = False
-
-        # Initialize binding params
-        bind_params = {
-            "_start": datetime_start,
-            "_stop": datetime_end,
-        }
-
-        # Initialise strings for the querying influx, it is not possible to parameterize this string
-        weather_params_str = '" or r._field == "'.join(weatherparams)
-        weather_models_str = '" or r.source == "'.join(source)
-        weather_location_name_str = '" or r.input_city == "'.join(
-            location_name.to_list()
-        )
-
-        # Create the query
-        query = f"""
-            from(bucket: "forecast_latest/autogen") 
-                |> range(start: {bind_params["_start"].strftime('%Y-%m-%dT%H:%M:%SZ')}, stop: {bind_params["_stop"].strftime('%Y-%m-%dT%H:%M:%SZ')}) 
-                |> filter(fn: (r) => r._measurement == "weather_tAhead" and (r._field == "{weather_params_str}") and (r.source == "{weather_models_str}") and (r.input_city == "{weather_location_name_str}"))
-        """
-
-        # Execute Query
-        result = _DataInterface.get_instance().exec_influx_query(query)
-
-        # For multiple Fields a list is returned.
-        if isinstance(result, list):
-            result = pd.concat(result)[["_value", "_field", "_time", "source"]]
-
-        # Check if response is empty
-        if not result.empty:
-            result = parse_influx_result(result, ["source", "input_city", "tAhead"])
-        else:
-            self.logger.warning("No weatherdata found. Returning empty dataframe")
-            return pd.DataFrame(
-                index=genereate_datetime_index(
-                    start=datetime_start,
-                    end=datetime_end,
-                    freq=resolution,
-                )
-            )
-
-        # Create a single dataframe with combined sources
-        if combine_sources:
-            self.logger.info("Combining sources into single dataframe")
-            result = self._combine_weather_sources(result)
+            result["source"] = 'optimum'
 
         # Compute source_run
-        result["created"] = self._get_source_run(result.index, result.tAhead)
-    
-        # Interpolate if nescesarry by input_city and additionnal groups
-        interpolation_grouping = ["input_city", "created"]
+        if type == "multiple_tAheads":
+            result["created"] = self._get_source_run(result.index, result.tAhead)
+        
+        # Interpolate if nescesarry by input_city and source
         result = (
-            result.groupby(interpolation_grouping)
+            result.groupby(grouping_indices)
             .resample(resolution)
             .interpolate(limit=11)
-            .drop(columns=interpolation_grouping)
-            .reset_index(interpolation_grouping)
+            .drop(columns=grouping_indices)
+            .reset_index(grouping_indices)
         )
 
         # Shift radiation by 30 minutes if resolution allows it
         if "radiation" in result.columns:
             shift_delta = -timedelta(minutes=30)
             if shift_delta % pd.Timedelta(resolution) == timedelta(0):
-                result["radiation"] = result.groupby(interpolation_grouping)[
-                    "radiation"
-                ].shift(1, shift_delta)
+                result["radiation"] = result.groupby(grouping_indices)["radiation"].shift(
+                    1, shift_delta
+                )
 
         # Drop extra rows not neccesary
         result = result[result.index >= datetime_start_original]

--- a/openstef_dbc/services/weather.py
+++ b/openstef_dbc/services/weather.py
@@ -234,7 +234,7 @@ class Weather:
         resolution: str = "15min",
         country: str = "NL",
         number_locations: int = 1,
-        type: chr = "smallest_tAhead",
+        type: str = "smallest_tAhead",
     ) -> pd.DataFrame:
         """Get weather data from database.
 
@@ -256,7 +256,7 @@ class Weather:
             resolution (str): Time resolution of the returned data, default: "15min"
             country (str): Country code (2-letter: ISO 3166-1). e.g. NL
             number_locations (int): number of weather locations desired
-            type (chr) : type of weather forecast (smallest_tAhead of multiple_tAheads)
+            type (str) : type of weather forecast (smallest_tAhead of multiple_tAheads)
         Returns:
             pd.DataFrame: The most recent weather prediction
 

--- a/openstef_dbc/services/weather.py
+++ b/openstef_dbc/services/weather.py
@@ -370,9 +370,7 @@ class Weather:
         if "radiation" in result.columns:
             shift_delta = -timedelta(minutes=30)
             if shift_delta % pd.Timedelta(resolution) == timedelta(0):
-                result["radiation"] = result.groupby(
-                    grouping_indices, include_groups=False
-                )["radiation"].shift(1, shift_delta)
+                result["radiation"] = result.groupby(grouping_indices)["radiation"].shift(1, shift_delta)
 
         # Drop extra rows not neccesary
         result = result[result.index >= datetime_start_original]

--- a/openstef_dbc/services/weather.py
+++ b/openstef_dbc/services/weather.py
@@ -506,12 +506,14 @@ class Weather:
             result = self._combine_weather_sources(result)
 
         # Changing interpolation strategy if indexes ares duplicated due to tAhead
-        interpolation_grouping = ['input_city']
+        interpolation_grouping = ["input_city"]
         index_duplicates = result.index.duplicated().any()
         if index_duplicates:
             # Compute creation_datetime
-            result['creation_datetime'] = result.index - pd.to_timedelta(result['tAhead'], unit="hour")
-            interpolation_grouping +=['creation_datetime']
+            result["creation_datetime"] = result.index - pd.to_timedelta(
+                result["tAhead"], unit="hour"
+            )
+            interpolation_grouping += ["creation_datetime"]
 
         # Interpolate if nescesarry by input_city and additionnal groups
         result = (
@@ -526,10 +528,9 @@ class Weather:
         if "radiation" in result.columns:
             shift_delta = -timedelta(minutes=30)
             if shift_delta % pd.Timedelta(resolution) == timedelta(0):
-                result["radiation"] = (
-                    result.groupby(interpolation_grouping)["radiation"]
-                    .shift(1, shift_delta)
-                )
+                result["radiation"] = result.groupby(interpolation_grouping)[
+                    "radiation"
+                ].shift(1, shift_delta)
 
         # Drop extra rows not neccesary
         result = result[result.index >= datetime_start_original]
@@ -545,7 +546,6 @@ class Weather:
             )
 
         return result
-
 
     def get_datetime_last_stored_knmi_weatherdata(self) -> datetime:
         """Returns datetime of latest KNMI run in influx Database. If no run is found return first unix time."""

--- a/openstef_dbc/services/weather.py
+++ b/openstef_dbc/services/weather.py
@@ -171,7 +171,7 @@ class Weather:
             raise ValueError("forecast_datetime must be a Series of datetime.")
 
         if not pd.api.types.is_numeric_dtype(tAhead):
-            raise ValueError("tahead must be a Series of intoru float.")
+            raise ValueError("tahead must be a Series of int or float.")
 
         if len(forecast_datetime) != len(tAhead):
             raise ValueError("forecast_datetime and tAhead must have the same length.")

--- a/openstef_dbc/services/write.py
+++ b/openstef_dbc/services/write.py
@@ -369,7 +369,7 @@ class Write:
 
         # Calculate tAheads
         timediffs = (
-            influx_df.index.tz_localize(None) - forecast_created_time
+            influx_df.index - forecast_created_time
         ).total_seconds() / 3600
         # Round it to the first bigger desired_t_ahead
         influx_df["tAhead"] = round_down_time_differences(timediffs, desired_t_aheads)
@@ -473,7 +473,7 @@ class Write:
             data=data,
             source=source,
             forecast_created_time=forecast_created_time,
-            table=table + "_tAheads",
+            table=table + "_tAhead",
             dbname=dbname,
             desired_t_aheads=desired_t_aheads,
             casting_dict=casting_dict,

--- a/openstef_dbc/services/write.py
+++ b/openstef_dbc/services/write.py
@@ -368,9 +368,7 @@ class Write:
         tag_columns.append("tAhead")
 
         # Calculate tAheads
-        timediffs = (
-            influx_df.index - forecast_created_time
-        ).total_seconds() / 3600
+        timediffs = (influx_df.index - forecast_created_time).total_seconds() / 3600
         # Round it to the first bigger desired_t_ahead
         influx_df["tAhead"] = round_down_time_differences(timediffs, desired_t_aheads)
 
@@ -426,7 +424,7 @@ class Write:
             tag_columns: (list) the column names used as tags in influx
             forecast_created_time: (datetime) the time at which the forecast was created
             desired_t_aheads: (list) the t_ahead values for which the data should be written
-            
+
         Returns:
             None
         """

--- a/tests/unit/data/combined_weatherdata_with_tAhead_test_data.csv
+++ b/tests/unit/data/combined_weatherdata_with_tAhead_test_data.csv
@@ -1,0 +1,6 @@
+;_time;_value;_field;_measurement;input_city;source;tAhead
+0;2022-01-01 00:00:00+00:00;3.6144495010375977;windspeed;weather;Rotterdam;harm_arome;0
+1;2022-01-01 01:00:00+00:00;3.5552268028259277;windspeed;weather;Rotterdam;harm_arome;1
+7;2022-01-01 02:00:00+00:00;1.4958148002624512;windspeed;weather;Rotterdam;harm_arome;2
+8;2022-01-01 01:00:00+00:00;0.625495970249176;windspeed;weather;Rotterdam;harm_arome;0
+14;2022-01-01 02:00:00+00:00;2.078191041946411;windspeed;weather;Rotterdam;harm_arome;1

--- a/tests/unit/services/test_weather.py
+++ b/tests/unit/services/test_weather.py
@@ -241,8 +241,7 @@ class TestWeather(BaseTestCase):
         expected_response.index.name = "datetime"
 
         self.assertTrue(response.equals(expected_response))
-        
-        
+
     @patch("openstef_dbc.services.weather._DataInterface")
     def test_get_single_location_weather_data_with_tAhead(self, MockDataInterface):
         """Data: dataframe contains weather data of multiple
@@ -256,8 +255,10 @@ class TestWeather(BaseTestCase):
 
         mock_Datainterface = MagicMock()
         MockDataInterface.get_instance.return_value = mock_Datainterface
-        mock_Datainterface.exec_influx_query.return_value = combined_weatherdata_with_tAhead
-        
+        mock_Datainterface.exec_influx_query.return_value = (
+            combined_weatherdata_with_tAhead
+        )
+
         weather = Weather()
         # Mocking influx query and get_weather_forecast_locations
         weather.get_weather_forecast_locations = lambda country, active: locations
@@ -275,27 +276,43 @@ class TestWeather(BaseTestCase):
             resolution="30min",
         )
         response.windspeed = np.round(response.windspeed, 1)
-        
+
         expected_response = pd.DataFrame(
-            {'creation_datetime': [pd.Timestamp('2022-01-01 00:00:00+0000', tz='UTC'), 
-                                   pd.Timestamp('2022-01-01 00:00:00+0000', tz='UTC'), 
-                                   pd.Timestamp('2022-01-01 00:00:00+0000', tz='UTC'), 
-                                   pd.Timestamp('2022-01-01 00:00:00+0000', tz='UTC'), 
-                                   pd.Timestamp('2022-01-01 00:00:00+0000', tz='UTC'), 
-                                   pd.Timestamp('2022-01-01 01:00:00+0000', tz='UTC'), 
-                                   pd.Timestamp('2022-01-01 01:00:00+0000', tz='UTC'), 
-                                   pd.Timestamp('2022-01-01 01:00:00+0000', tz='UTC')],
-             'source': ['harm_arome', np.nan, 'harm_arome', np.nan, 'harm_arome', 'harm_arome', np.nan, 'harm_arome'], 
-             'tAhead': [0.0, 0.5, 1.0, 1.5, 2.0, 0.0, 0.5, 1.0], 
-            'windspeed': [3.6, 3.6, 3.6, 2.5, 1.5, 0.6, 1.4, 2.1]},
-            index= [pd.Timestamp('2022-01-01 00:00:00+0000', tz='UTC'), 
-                          pd.Timestamp('2022-01-01 00:30:00+0000', tz='UTC'), 
-                          pd.Timestamp('2022-01-01 01:00:00+0000', tz='UTC'),  
-                          pd.Timestamp('2022-01-01 01:30:00+0000', tz='UTC'), 
-                          pd.Timestamp('2022-01-01 02:00:00+0000', tz='UTC'), 
-                          pd.Timestamp('2022-01-01 01:00:00+0000', tz='UTC'), 
-                          pd.Timestamp('2022-01-01 01:30:00+0000', tz='UTC'), 
-                          pd.Timestamp('2022-01-01 02:00:00+0000', tz='UTC')])
+            {
+                "creation_datetime": [
+                    pd.Timestamp("2022-01-01 00:00:00+0000", tz="UTC"),
+                    pd.Timestamp("2022-01-01 00:00:00+0000", tz="UTC"),
+                    pd.Timestamp("2022-01-01 00:00:00+0000", tz="UTC"),
+                    pd.Timestamp("2022-01-01 00:00:00+0000", tz="UTC"),
+                    pd.Timestamp("2022-01-01 00:00:00+0000", tz="UTC"),
+                    pd.Timestamp("2022-01-01 01:00:00+0000", tz="UTC"),
+                    pd.Timestamp("2022-01-01 01:00:00+0000", tz="UTC"),
+                    pd.Timestamp("2022-01-01 01:00:00+0000", tz="UTC"),
+                ],
+                "source": [
+                    "harm_arome",
+                    np.nan,
+                    "harm_arome",
+                    np.nan,
+                    "harm_arome",
+                    "harm_arome",
+                    np.nan,
+                    "harm_arome",
+                ],
+                "tAhead": [0.0, 0.5, 1.0, 1.5, 2.0, 0.0, 0.5, 1.0],
+                "windspeed": [3.6, 3.6, 3.6, 2.5, 1.5, 0.6, 1.4, 2.1],
+            },
+            index=[
+                pd.Timestamp("2022-01-01 00:00:00+0000", tz="UTC"),
+                pd.Timestamp("2022-01-01 00:30:00+0000", tz="UTC"),
+                pd.Timestamp("2022-01-01 01:00:00+0000", tz="UTC"),
+                pd.Timestamp("2022-01-01 01:30:00+0000", tz="UTC"),
+                pd.Timestamp("2022-01-01 02:00:00+0000", tz="UTC"),
+                pd.Timestamp("2022-01-01 01:00:00+0000", tz="UTC"),
+                pd.Timestamp("2022-01-01 01:30:00+0000", tz="UTC"),
+                pd.Timestamp("2022-01-01 02:00:00+0000", tz="UTC"),
+            ],
+        )
         expected_response.index.name = "datetime"
 
         self.assertTrue(response.equals(expected_response))

--- a/tests/unit/services/test_weather.py
+++ b/tests/unit/services/test_weather.py
@@ -263,10 +263,6 @@ class TestWeather(BaseTestCase):
         # Mocking influx query and get_weather_forecast_locations
         weather.get_weather_forecast_locations = lambda country, active: locations
 
-        nearest_location = weather._get_nearest_weather_locations(
-            location=[52, 4.7], number_locations=1
-        ).to_list()
-
         response = weather.get_weather_tAhead_data(
             location=[52, 4.7],
             weatherparams="windspeed",

--- a/tests/unit/services/test_weather.py
+++ b/tests/unit/services/test_weather.py
@@ -156,11 +156,20 @@ class TestWeather(BaseTestCase):
             datetime_end=datetime_end,
             number_locations=2,
             resolution="30min",
+            source="harm_arome",
         )
         response.windspeed = np.round(response.windspeed, 1)
 
         expected_response = pd.DataFrame(
             {
+                "source": [
+                    "harm_arome",
+                    "harm_arome",
+                    "harm_arome",
+                    "harm_arome",
+                    "harm_arome",
+                    "harm_arome",
+                ],
                 "input_city": [
                     "Amsterdam",
                     "Amsterdam",
@@ -168,14 +177,6 @@ class TestWeather(BaseTestCase):
                     "Rotterdam",
                     "Rotterdam",
                     "Rotterdam",
-                ],
-                "source": [
-                    "harm_arome",
-                    np.nan,
-                    "harm_arome",
-                    "harm_arome",
-                    np.nan,
-                    "harm_arome",
                 ],
                 "windspeed": [6.9, 4.0, 1.2, 7.6, 4.5, 1.5],
                 "distance": [44.2, 44.2, 44.2, 18.3, 18.3, 18.3],
@@ -190,7 +191,6 @@ class TestWeather(BaseTestCase):
             ),
         )
         expected_response.index.name = "datetime"
-
         self.assertTrue(response.equals(expected_response))
 
     @patch("openstef_dbc.services.weather._DataInterface")
@@ -232,7 +232,7 @@ class TestWeather(BaseTestCase):
 
         expected_response = pd.DataFrame(
             {
-                "source": ["harm_arome", np.nan, "harm_arome"],
+                "source": ["optimum", "optimum", "optimum"],
                 "windspeed": [7.6, 4.5, 1.5],
             },
             index=pd.date_range(
@@ -242,7 +242,7 @@ class TestWeather(BaseTestCase):
             ),
         )
         expected_response.index.name = "datetime"
-
+        
         self.assertTrue(response.equals(expected_response))
 
     @patch("openstef_dbc.services.weather._DataInterface")
@@ -266,18 +266,29 @@ class TestWeather(BaseTestCase):
         # Mocking influx query and get_weather_forecast_locations
         weather.get_weather_forecast_locations = lambda country, active: locations
 
-        response = weather.get_weather_tAhead_data(
+        response = weather.get_weather_data(
             location=[52, 4.7],
             weatherparams="windspeed",
             datetime_start=datetime_start,
             datetime_end=datetime_end,
             number_locations=1,
             resolution="30min",
+            type="multiple_tAheads",
         )
         response.windspeed = np.round(response.windspeed, 1)
 
         expected_response = pd.DataFrame(
             {
+                "source": [
+                    "optimum",
+                    "optimum",
+                    "optimum",
+                    "optimum",
+                    "optimum",
+                    "optimum",
+                    "optimum",
+                    "optimum",
+                ],
                 "created": [
                     pd.Timestamp("2022-01-01 00:00:00+0000", tz="UTC"),
                     pd.Timestamp("2022-01-01 00:00:00+0000", tz="UTC"),
@@ -287,16 +298,6 @@ class TestWeather(BaseTestCase):
                     pd.Timestamp("2022-01-01 01:00:00+0000", tz="UTC"),
                     pd.Timestamp("2022-01-01 01:00:00+0000", tz="UTC"),
                     pd.Timestamp("2022-01-01 01:00:00+0000", tz="UTC"),
-                ],
-                "source": [
-                    "harm_arome",
-                    np.nan,
-                    "harm_arome",
-                    np.nan,
-                    "harm_arome",
-                    "harm_arome",
-                    np.nan,
-                    "harm_arome",
                 ],
                 "tAhead": [0.0, 0.5, 1.0, 1.5, 2.0, 0.0, 0.5, 1.0],
                 "windspeed": [3.6, 3.6, 3.6, 2.5, 1.5, 0.6, 1.4, 2.1],

--- a/tests/unit/services/test_weather.py
+++ b/tests/unit/services/test_weather.py
@@ -71,9 +71,9 @@ locations = [
 
 weather = Weather()
 
+
 @patch("openstef_dbc.services.weather.Write", MagicMock())
 class TestWeather(BaseTestCase):
-             
     @patch("openstef_dbc.services.weather._DataInterface", MagicMock())
     def test_combine_weather_sources_fill_nan_values(self):
         """Data: dataframe contains weather data of multiple sources for same timpestamp with np.nan-values
@@ -242,7 +242,7 @@ class TestWeather(BaseTestCase):
             ),
         )
         expected_response.index.name = "datetime"
-        
+
         self.assertTrue(response.equals(expected_response))
 
     @patch("openstef_dbc.services.weather._DataInterface")
@@ -316,33 +316,43 @@ class TestWeather(BaseTestCase):
         expected_response.index.name = "datetime"
 
         self.assertTrue(response.equals(expected_response))
-        
+
     def test_source_run_valid_input(self):
         """Test with valid input."""
-        datetime_input = pd.Series(datetime(2024, 12, 10, 15, 30))  # December 10 2024 at 15:30 
+        datetime_input = pd.Series(
+            datetime(2024, 12, 10, 15, 30)
+        )  # December 10 2024 at 15:30
         tAhead = pd.Series(6)
         expected_result = pd.Series(datetime(2024, 12, 10, 9, 30))  # 6 hours ahead
-        pd.testing.assert_series_equal(weather._get_source_run(datetime_input, tAhead), expected_result)
+        pd.testing.assert_series_equal(
+            weather._get_source_run(datetime_input, tAhead), expected_result
+        )
 
     def test_source_run_vzero_tAhead(self):
         """Test with tAhead equal to 0 (no substrasction)."""
         datetime_input = pd.Series(datetime(2024, 12, 10, 15, 30))
         tAhead = pd.Series(0)
-        pd.testing.assert_series_equal(weather._get_source_run(datetime_input, tAhead), datetime_input)
+        pd.testing.assert_series_equal(
+            weather._get_source_run(datetime_input, tAhead), datetime_input
+        )
 
     def test_source_run_negative_tAhead(self):
-        """Test with negative tAhead """
+        """Test with negative tAhead"""
         datetime_input = pd.Series(datetime(2024, 12, 10, 15, 30))
         tAhead = pd.Series(-3)
         expected_result = pd.Series(datetime(2024, 12, 10, 18, 30))  # 3 heures after
-        pd.testing.assert_series_equal(weather._get_source_run(datetime_input, tAhead), expected_result)
+        pd.testing.assert_series_equal(
+            weather._get_source_run(datetime_input, tAhead), expected_result
+        )
 
     def test_source_run_large_tAhead(self):
-        """Test with very large tAhead """
+        """Test with very large tAhead"""
         datetime_input = pd.Series(datetime(2024, 12, 10, 15, 30))
         tAhead = pd.Series(1000)
         expected_result = pd.Series(datetime(2024, 10, 29, 23, 30))  # 1000 heures ahead
-        pd.testing.assert_series_equal(weather._get_source_run(datetime_input, tAhead), expected_result)
+        pd.testing.assert_series_equal(
+            weather._get_source_run(datetime_input, tAhead), expected_result
+        )
 
     def test_source_run_invalid_datetime_input(self):
         """Test with unvalid datetime."""
@@ -352,7 +362,7 @@ class TestWeather(BaseTestCase):
             weather._get_source_run(datetime_input, tAhead)
 
     def test_source_run_invalid_tAhead(self):
-        """Test with unvalid tAhead """
+        """Test with unvalid tAhead"""
         datetime_input = pd.Series(datetime(2024, 12, 10, 15, 30))
         tAhead = pd.Series("six")  # Not a number
         with self.assertRaises(ValueError):
@@ -362,15 +372,22 @@ class TestWeather(BaseTestCase):
         """Test with a float tAhead."""
         datetime_input = pd.Series(datetime(2024, 12, 10, 15, 30))
         tAhead = pd.Series(2.5)
-        expected_result = pd.Series(datetime(2024, 12, 10, 13, 0))  # 2 hours and 30 minutes ahead
-        pd.testing.assert_series_equal(weather._get_source_run(datetime_input, tAhead), expected_result)
-    
+        expected_result = pd.Series(
+            datetime(2024, 12, 10, 13, 0)
+        )  # 2 hours and 30 minutes ahead
+        pd.testing.assert_series_equal(
+            weather._get_source_run(datetime_input, tAhead), expected_result
+        )
+
     def test_source_run_int_tAhead(self):
         """Test with a int tAhead."""
         datetime_input = pd.Series(datetime(2024, 12, 10, 15, 30))
         tAhead = pd.Series(2)
         expected_result = pd.Series(datetime(2024, 12, 10, 13, 30))  # 2 hours
-        pd.testing.assert_series_equal(weather._get_source_run(datetime_input, tAhead), expected_result)
+        pd.testing.assert_series_equal(
+            weather._get_source_run(datetime_input, tAhead), expected_result
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/services/test_write.py
+++ b/tests/unit/services/test_write.py
@@ -5,7 +5,7 @@
 import unittest
 from datetime import datetime
 import pandas as pd
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 # from openstef_dbc.services.systems import Systems
 from openstef_dbc.services.write import Write
@@ -21,6 +21,7 @@ class TestWriteService(unittest.TestCase):
     @patch("openstef_dbc.services.write._DataInterface")
     def test_write_forecast_tahead_happy_flow(self, data_interface_mock):
         """Test happy flow of writing forecasts. The actual writing is mocked"""
+        
         data_interface_mock.get_instance.return_value.exec_influx_write.return_value = (
             True
         )
@@ -46,11 +47,17 @@ class TestWriteService(unittest.TestCase):
         writer.write_forecast(data=example_data, t_ahead_series=True)
 
         # Assert
-        assert writer == ""
+        assert writer
 
-    def test_write_weather_forecast_data(self):
+    @patch("openstef_dbc.services.write._DataInterface")
+    def test_write_weather_forecast_data(self, MockDataInterface):
         """Test happy flow of writing weather forecasts."""
 
+        mock_instance = MagicMock()
+        MockDataInterface.get_instance.return_value = mock_instance
+        MockDataInterface.get_instance.return_value.exec_influx_write.return_value = (
+            True
+        )
         # Arange
         writer = Write()
         example_data = pd.DataFrame(
@@ -63,35 +70,35 @@ class TestWriteService(unittest.TestCase):
                 windspeed=[1000, 1100],
             ),
         )
+        example_forecast_created_time = pd.to_datetime("2023-01-01 09:00:00+00:00")
         table_name = "weather_forecast"
 
         # Act
         writer.write_weather_forecast_data(
             data=example_data,
             source="test_source",
-            table_name=table_name,
+            table=table_name,
             dbname="test_db",
+            forecast_created_time=example_forecast_created_time,
             )
 
-
         # Assert
-        #  TODO: make sure the called_with is correct + mock the influx writing part
-        assert writer._write_weather_forecast_data_latest.called_with(
-            data=example_data,
-            source="test_source",
-            table_name=table_name,
-            dbname="test_db",
-        )
+        # write_weather_forecast_data should write in two buckets
+        self.assertEqual(MockDataInterface.get_instance.call_count, 2)
+        
+       # Verifying call arguments (table name and number of rows of inserted dataframe)
+        calls = mock_instance.exec_influx_write.call_args_list
 
-        #  TODO: make sure the called_with is correct + mock the influx writing part
-        assert writer._write_weather_forecast_data_t_ahead.called_with(
-            data=example_data,
-            source="test_source",
-            table_name=table_name + "_t_ahead",
-            dbname="test_db",
-        )
+        # First call
+        first_call = calls[0]
+        first_call_args = first_call[0][0]  
+        first_call_kwargs = first_call[1] 
+        assert first_call_kwargs['measurement'] == table_name
+        assert first_call_args.shape[0] == 2 # whatever default desired_t_ahead
 
-    def test_write_weather_forecast_data_latest(self):
-
-
-
+        # Second call
+        second_call = calls[1]
+        second_call_args = second_call[0][0] 
+        second_call_kwargs = second_call[1]  
+        assert second_call_kwargs['measurement'] == (table_name + "_tAhead")
+        assert second_call_args.shape[0] == 1 # only default desired_t_ahead

--- a/tests/unit/services/test_write.py
+++ b/tests/unit/services/test_write.py
@@ -21,7 +21,7 @@ class TestWriteService(unittest.TestCase):
     @patch("openstef_dbc.services.write._DataInterface")
     def test_write_forecast_tahead_happy_flow(self, data_interface_mock):
         """Test happy flow of writing forecasts. The actual writing is mocked"""
-        
+
         data_interface_mock.get_instance.return_value.exec_influx_write.return_value = (
             True
         )
@@ -80,25 +80,25 @@ class TestWriteService(unittest.TestCase):
             table=table_name,
             dbname="test_db",
             forecast_created_time=example_forecast_created_time,
-            )
+        )
 
         # Assert
         # write_weather_forecast_data should write in two buckets
         self.assertEqual(MockDataInterface.get_instance.call_count, 2)
-        
-       # Verifying call arguments (table name and number of rows of inserted dataframe)
+
+        # Verifying call arguments (table name and number of rows of inserted dataframe)
         calls = mock_instance.exec_influx_write.call_args_list
 
         # First call
         first_call = calls[0]
-        first_call_args = first_call[0][0]  
-        first_call_kwargs = first_call[1] 
-        assert first_call_kwargs['measurement'] == table_name
-        assert first_call_args.shape[0] == 2 # whatever default desired_t_ahead
+        first_call_args = first_call[0][0]
+        first_call_kwargs = first_call[1]
+        assert first_call_kwargs["measurement"] == table_name
+        assert first_call_args.shape[0] == 2  # whatever default desired_t_ahead
 
         # Second call
         second_call = calls[1]
-        second_call_args = second_call[0][0] 
-        second_call_kwargs = second_call[1]  
-        assert second_call_kwargs['measurement'] == (table_name + "_tAhead")
-        assert second_call_args.shape[0] == 1 # only default desired_t_ahead
+        second_call_args = second_call[0][0]
+        second_call_kwargs = second_call[1]
+        assert second_call_kwargs["measurement"] == (table_name + "_tAhead")
+        assert second_call_args.shape[0] == 1  # only default desired_t_ahead

--- a/tests/unit/services/test_write.py
+++ b/tests/unit/services/test_write.py
@@ -42,6 +42,56 @@ class TestWriteService(unittest.TestCase):
         )
         data_interface_mock()
 
+        # Act
         writer.write_forecast(data=example_data, t_ahead_series=True)
 
-        assert writer
+        # Assert
+        assert writer == ""
+
+    def test_write_weather_forecast_data(self):
+        """Test happy flow of writing weather forecasts."""
+
+        # Arange
+        writer = Write()
+        example_data = pd.DataFrame(
+            index=pd.to_datetime(
+                ["2023-01-01 10:00:00+00:00", "2023-01-01 10:15:00+00:00"]
+            ),
+            data=dict(
+                input_city=["city1", "city1"],
+                temp=[23.1, 23.0],
+                windspeed=[1000, 1100],
+            ),
+        )
+        table_name = "weather_forecast"
+
+        # Act
+        writer.write_weather_forecast_data(
+            data=example_data,
+            source="test_source",
+            table_name=table_name,
+            dbname="test_db",
+            )
+
+
+        # Assert
+        #  TODO: make sure the called_with is correct + mock the influx writing part
+        assert writer._write_weather_forecast_data_latest.called_with(
+            data=example_data,
+            source="test_source",
+            table_name=table_name,
+            dbname="test_db",
+        )
+
+        #  TODO: make sure the called_with is correct + mock the influx writing part
+        assert writer._write_weather_forecast_data_t_ahead.called_with(
+            data=example_data,
+            source="test_source",
+            table_name=table_name + "_t_ahead",
+            dbname="test_db",
+        )
+
+    def test_write_weather_forecast_data_latest(self):
+
+
+

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -11,9 +11,9 @@ class TestAppSettings(TestCase):
     def test_create_forecast_task_parsing_weather_sources_env(self):
         """Test happy flow of create forecast task."""
         # Arrange
-        os.environ["OPENSTEF_OPTIMUM_WEATHER_SOURCES"] = (
-            '["weather_source_1","weather_source_2"]'
-        )
+        os.environ[
+            "OPENSTEF_OPTIMUM_WEATHER_SOURCES"
+        ] = '["weather_source_1","weather_source_2"]'
 
         # Act
         settings = AppSettings()

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -11,9 +11,9 @@ class TestAppSettings(TestCase):
     def test_create_forecast_task_parsing_weather_sources_env(self):
         """Test happy flow of create forecast task."""
         # Arrange
-        os.environ[
-            "OPENSTEF_OPTIMUM_WEATHER_SOURCES"
-        ] = '["weather_source_1","weather_source_2"]'
+        os.environ["OPENSTEF_OPTIMUM_WEATHER_SOURCES"] = (
+            '["weather_source_1","weather_source_2"]'
+        )
 
         # Act
         settings = AppSettings()


### PR DESCRIPTION
New influxDB measurement created : weather_tAhead.

weather_tAhead : contains all desired tAheads of weather forecast archives. Those forecasts could be used to train a quantile model taking into account forecast horizon (the lower the tAhead, the less uncertain the forecast).

weather : contains only the smallest tAhead for each timestamp. Those forecasts are currently used to train and create_forecast.

Get method : 
User can now specify the weather forecast type (smallest_tAhead or multiple_tAhead) to choose which measurement openstef-dbc should extract the weather from.

Write method : 
Every time a weather forecast is stored into influx, it is written in both weather (without tAhead information) and weather_tAhead measurements.

