### PR TITLE
Adapt to sqlachemy 2

### DIFF
--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -46,7 +46,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     # Restore
     - name: Restore pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip

--- a/openstef_dbc/data_interface.py
+++ b/openstef_dbc/data_interface.py
@@ -290,7 +290,7 @@ class _DataInterface(metaclass=Singleton):
         try:
             with self.sql_engine.connect() as connection:
                 response = connection.execute(text(statement).bindparams(**params))
-
+                connection.commit()
                 self.logger.info(
                     f"Added {response.rowcount} new systems to the systems table in the {self.sql_db_type} database"
                 )

--- a/openstef_dbc/data_interface.py
+++ b/openstef_dbc/data_interface.py
@@ -289,7 +289,7 @@ class _DataInterface(metaclass=Singleton):
     def exec_sql_write(self, statement: str, params: dict = None) -> None:
         try:
             with self.sql_engine.connect() as connection:
-                response = connection.execute(statement, params=params)
+                response = connection.execute(text(statement).bindparams(**params))
 
                 self.logger.info(
                     f"Added {response.rowcount} new systems to the systems table in the {self.sql_db_type} database"

--- a/openstef_dbc/data_interface.py
+++ b/openstef_dbc/data_interface.py
@@ -9,7 +9,7 @@ import pandas as pd
 import numpy as np
 import requests
 import sqlalchemy
-
+from sqlalchemy import text, bindparam
 from openstef_dbc import Singleton
 from openstef_dbc.ktp_api import KtpApi
 from openstef_dbc.log import logging
@@ -266,7 +266,7 @@ class _DataInterface(metaclass=Singleton):
             with self.sql_engine.connect() as connection:
                 if params is None:
                     params = {}
-                cursor = connection.execute(query, **params)
+                cursor = connection.execute(text(query).bindparams([bindparam(p, expanding=True) for p in params]))
                 if cursor.cursor is not None:
                     return pd.DataFrame(cursor.fetchall())
         except sqlalchemy.exc.OperationalError as e:

--- a/openstef_dbc/data_interface.py
+++ b/openstef_dbc/data_interface.py
@@ -266,7 +266,8 @@ class _DataInterface(metaclass=Singleton):
             with self.sql_engine.connect() as connection:
                 if params is None:
                     params = {}
-                cursor = connection.execute(text(query).bindparams([bindparam(p, expanding=True) for p in params]))
+                cursor = connection.execute(text(query).bindparams(**params))
+                # cursor = connection.execute(text(query).bindparams([bindparam(p, expanding=True) for p in params]))
                 if cursor.cursor is not None:
                     return pd.DataFrame(cursor.fetchall())
         except sqlalchemy.exc.OperationalError as e:

--- a/openstef_dbc/data_interface.py
+++ b/openstef_dbc/data_interface.py
@@ -267,7 +267,6 @@ class _DataInterface(metaclass=Singleton):
                 if params is None:
                     params = {}
                 cursor = connection.execute(text(query).bindparams(**params))
-                # cursor = connection.execute(text(query).bindparams([bindparam(p, expanding=True) for p in params]))
                 if cursor.cursor is not None:
                     return pd.DataFrame(cursor.fetchall())
         except sqlalchemy.exc.OperationalError as e:

--- a/openstef_dbc/services/model_input.py
+++ b/openstef_dbc/services/model_input.py
@@ -255,7 +255,7 @@ class ModelInput:
         """ "This function retrieves the power curve coefficients from the genericpowercurves table,
         using the turbine type as input."""
         bind_params = {"turbine_type": turbine_type}
-        query = "SELECT * FROM genericpowercurves WHERE name = %(turbine_type)s"
+        query = "SELECT * FROM genericpowercurves WHERE name = :turbine_type"
 
         result = _DataInterface.get_instance().exec_sql_query(query, bind_params)
 

--- a/openstef_dbc/services/prediction_job.py
+++ b/openstef_dbc/services/prediction_job.py
@@ -214,7 +214,7 @@ class PredictionJobRetriever:
             LEFT JOIN `customers` as cu ON cak.cid = cu.id 
             LEFT JOIN `customers_predictions` as cp ON cu.id = cp.customer_id 
             LEFT JOIN `predictions` as p ON p.id = cp.prediction_id 
-            WHERE cak.api_key = :apiKey 
+            WHERE cak.apiKey = :apiKey 
         """
         result = _DataInterface.get_instance().exec_sql_query(query, bind_params)
         if isinstance(result, pd.DataFrame) and result.empty:
@@ -289,7 +289,7 @@ class PredictionJobRetriever:
             WHERE
                 p.id = pq.prediction_id AND
                 qs.id = pq.quantile_set_id AND
-                p.id IN  :prediction_jobs_ids_str
+                p.id IN  ({prediction_jobs_ids_str})
             ORDER BY prediction_id
             ;
         """

--- a/openstef_dbc/services/prediction_job.py
+++ b/openstef_dbc/services/prediction_job.py
@@ -214,7 +214,7 @@ class PredictionJobRetriever:
             LEFT JOIN `customers` as cu ON cak.cid = cu.id 
             LEFT JOIN `customers_predictions` as cp ON cu.id = cp.customer_id 
             LEFT JOIN `predictions` as p ON p.id = cp.prediction_id 
-            WHERE cak.api_key = %(apiKey)s 
+            WHERE cak.api_key = :apiKey 
         """
         result = _DataInterface.get_instance().exec_sql_query(query, bind_params)
         if isinstance(result, pd.DataFrame) and result.empty:
@@ -264,7 +264,7 @@ class PredictionJobRetriever:
             SELECT
                 p.ean 
             FROM `predictions` as p  
-            WHERE p.id = %(pid)s 
+            WHERE p.id = :pid 
         """
         result = _DataInterface.get_instance().exec_sql_query(query, bind_params)
         if isinstance(result, pd.DataFrame) and result.empty:
@@ -289,7 +289,7 @@ class PredictionJobRetriever:
             WHERE
                 p.id = pq.prediction_id AND
                 qs.id = pq.quantile_set_id AND
-                p.id IN  ({prediction_jobs_ids_str})
+                p.id IN  :prediction_jobs_ids_str
             ORDER BY prediction_id
             ;
         """

--- a/openstef_dbc/services/splitting.py
+++ b/openstef_dbc/services/splitting.py
@@ -50,7 +50,7 @@ class Splitting:
         result = _DataInterface.get_instance().exec_sql_query(query, bind_params)
 
         # Make output dict
-        if result is not None:
+        if not result.empty:
             result = result.set_index("coef_name")
             if mean:
                 result = result.to_dict()["AVG(ec.coef_value)"]

--- a/openstef_dbc/services/splitting.py
+++ b/openstef_dbc/services/splitting.py
@@ -36,15 +36,15 @@ class Splitting:
             bind_params = {"pid": pj["id"], "dstart": start_date.isoformat()}
             query = (
                 "SELECT ec.coef_name, AVG(ec.coef_value) FROM energy_split_coefs as ec "
-                "WHERE ec.pid = %(pid)s AND ec.created > %(dstart)s GROUP BY ec.coef_name "
+                "WHERE ec.pid = :pid AND ec.created > :dstart GROUP BY ec.coef_name "
             )
         # Retrieve latest coefficients otherwise
         else:
             bind_params = {"pid": pj["id"]}
             query = (
-                "SELECT ec.coef_name,ec.coef_value FROM energy_split_coefs as ec WHERE  ec.pid = %(pid)s "
+                "SELECT ec.coef_name,ec.coef_value FROM energy_split_coefs as ec WHERE  ec.pid = :pid "
                 "AND ec.created = (SELECT max(energy_split_coefs.created) from energy_split_coefs "
-                "WHERE energy_split_coefs.pid = %(pid)s)"
+                "WHERE energy_split_coefs.pid = :pid)"
             )
         # Execute query
         result = _DataInterface.get_instance().exec_sql_query(query, bind_params)

--- a/openstef_dbc/services/systems.py
+++ b/openstef_dbc/services/systems.py
@@ -40,22 +40,22 @@ class Systems:
             "radius": str(radius),
         }
         query = """
-                    SELECT `sid`, `lat`, `lon`,`region`, ( 6371 * acos( cos( radians(%(lat)s) ) \
-                * cos( radians( lat ) ) * cos( radians( lon ) - radians(%(lon)s) ) + sin( radians(%(lat)s) ) \
+                    SELECT `sid`, `lat`, `lon`,`region`, ( 6371 * acos( cos( radians(:lat) ) \
+                * cos( radians( lat ) ) * cos( radians( lon ) - radians(:lon) ) + sin( radians(:lat) ) \
                 * sin( radians( lat ) ) ) ) AS `distance` \
                 FROM `systems`
-                WHERE `qual` > '%(quality)s'
+                WHERE `qual` > ':quality'
                 """
 
         # Extend query
         if freq is not None:
             bind_params["freq"] = str(freq)
-            query += """ AND `freq` <= %(freq)s"""
+            query += """ AND `freq` <= :freq"""
         if lag_systems is not None:
-            query += """ AND `lagSystems` <= %(quality)s"""
+            query += """ AND `lagSystems` <= :quality"""
 
         # Limit radius to given input radius
-        query += """ HAVING `distance` < %(radius)s ORDER BY `distance`;"""
+        query += """ HAVING `distance` < :radius ORDER BY `distance`;"""
 
         result = _DataInterface.get_instance().exec_sql_query(query, bind_params)
         return result
@@ -82,7 +82,7 @@ class Systems:
         SELECT * from systems
         INNER JOIN predictions_systems
             ON predictions_systems.system_id=systems.sid
-        WHERE predictions_systems.prediction_id=%(pid)s
+        WHERE predictions_systems.prediction_id=:pid
         """
 
         systems = _DataInterface.get_instance().exec_sql_query(
@@ -111,12 +111,12 @@ class Systems:
 
         if limit is not None:
             bind_params["limit"] = limit
-            limit_query = f"LIMIT %(limit)s"
+            limit_query = f"LIMIT :limit"
 
         query = f"""
             SELECT sid, qual, freq, lag
             FROM systems
-            WHERE left(sid, 3) = 'pv_' AND autoupdate = %(autoupdate)s
+            WHERE left(sid, 3) = 'pv_' AND autoupdate = :autoupdate
             ORDER BY RAND() {limit_query}
         """
 
@@ -138,7 +138,7 @@ class Systems:
                 sa.apiKey 
             FROM `systems` as s 
             LEFT JOIN `systemsApiKeys` as sa ON s.measurements_customer_api_key_id = sa.id 
-            WHERE s.sid = %(system)s;
+            WHERE s.sid = :system;
         """
 
         result = _DataInterface.get_instance().exec_sql_query(query, bind_params)

--- a/openstef_dbc/services/weather.py
+++ b/openstef_dbc/services/weather.py
@@ -43,7 +43,7 @@ class Weather:
         query = """
             SELECT input_city as city, lat, lon, country
             FROM weatherforecastlocations
-            WHERE country = %(country)s AND active = %(active)s
+            WHERE country = :country AND active = :active
         """
         result = _DataInterface.get_instance().exec_sql_query(query, bind_params)
 
@@ -136,7 +136,7 @@ class Weather:
 
         # Query corresponding (lat, lon) from SQL database
         binding_params = {"city": location_name}
-        query = "SELECT lat, lon from NameToLatLon where regionInput = %(city)s"
+        query = "SELECT lat, lon from NameToLatLon where regionInput = :city"
         location = _DataInterface.get_instance().exec_sql_query(query, binding_params)
 
         # If not found

--- a/openstef_dbc/services/write.py
+++ b/openstef_dbc/services/write.py
@@ -21,14 +21,13 @@ class Write:
 
     def write_location(self, location_name: str, location: Tuple[float, float]) -> None:
         bind_params = {
-            "table_name": "NameToLatLon",
             "loc": location_name,
             "lat": location[0],
             "lon": location[1],
         }
 
         statement = (
-            "INSERT INTO :table_name (regionInput, lat,lon) VALUES (:loc, :lat, :lon)"
+            "INSERT INTO NameToLatLon (regionInput, lat,lon) VALUES (:loc, :lat, :lon)"
         )
 
         _DataInterface.get_instance().exec_sql_write(statement, params=bind_params)

--- a/openstef_dbc/services/write.py
+++ b/openstef_dbc/services/write.py
@@ -27,7 +27,7 @@ class Write:
             "lon": location[1],
         }
 
-        statement = "INSERT INTO %(table_name)s (regionInput, lat,lon) VALUES (%(loc)s, %(lat)s, %(lon)s)"
+        statement = "INSERT INTO :table_name (regionInput, lat,lon) VALUES (:loc, :lat, :lon)"
 
         _DataInterface.get_instance().exec_sql_write(statement, params=bind_params)
 

--- a/openstef_dbc/services/write.py
+++ b/openstef_dbc/services/write.py
@@ -27,7 +27,9 @@ class Write:
             "lon": location[1],
         }
 
-        statement = "INSERT INTO :table_name (regionInput, lat,lon) VALUES (:loc, :lat, :lon)"
+        statement = (
+            "INSERT INTO :table_name (regionInput, lat,lon) VALUES (:loc, :lat, :lon)"
+        )
 
         _DataInterface.get_instance().exec_sql_write(statement, params=bind_params)
 

--- a/tests/integration/test_database_connection.py
+++ b/tests/integration/test_database_connection.py
@@ -57,7 +57,6 @@ class TestDataBaseConnexion(unittest.TestCase):
 
     @unittest.skip  # Skip because it need the db to be set up
     def test_get_ean_for_pid(self):
-
         pj_retriever = PredictionJobRetriever()
 
         response = pj_retriever.get_ean_for_pid(1)

--- a/tests/integration/test_database_connection.py
+++ b/tests/integration/test_database_connection.py
@@ -13,6 +13,7 @@ import unittest
 
 from openstef_dbc.data_interface import _DataInterface
 from openstef_dbc.database import DataBase
+from openstef.data_classes.prediction_job import PredictionJobDataClass
 from openstef_dbc.services.prediction_job import PredictionJobRetriever
 from tests.integration.mock_influx_db_admin import MockInfluxDBAdmin
 
@@ -39,15 +40,19 @@ class TestDataBaseConnexion(unittest.TestCase):
         
         pj_retriever = PredictionJobRetriever()
         
-        pjs = pj_retriever.get_prediction_jobs()       
+        response = pj_retriever.get_prediction_jobs()       
+        assert isinstance(response, list)
+        assert isinstance(response[0], PredictionJobDataClass)
+
         
         
     def test_get_pids_for_api_key(self):
         
         pj_retriever = PredictionJobRetriever()
 
-        pj_retriever.get_pids_for_api_key('random_api_key')
-    
+        response = pj_retriever.get_pids_for_api_key('random_api_key')
+        assert isinstance(response, list)
+
     
     # def test_get_ean_for_pid(self):
     

--- a/tests/integration/test_database_connection.py
+++ b/tests/integration/test_database_connection.py
@@ -37,7 +37,6 @@ class TestDataBaseConnexion(unittest.TestCase):
 
     @unittest.skip  # Skip because it need the db to be set up
     def test_sql_db_available(self):
-
         assert self.di.check_sql_available() == True
 
     @unittest.skip  # Skip because it need the db to be set up

--- a/tests/integration/test_database_connection.py
+++ b/tests/integration/test_database_connection.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2017-2022 Contributors to the OpenSTEF project <korte.termijn.prognoses@alliander.com>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+from datetime import datetime
+import pytz
+
+from pandas import Timestamp
+import pandas as pd
+import numpy as np
+import unittest
+
+
+from openstef_dbc.data_interface import _DataInterface
+from openstef_dbc.database import DataBase
+from openstef_dbc.services.prediction_job import PredictionJobRetriever
+from tests.integration.mock_influx_db_admin import MockInfluxDBAdmin
+
+from tests.integration.settings import Settings
+
+UTC = pytz.timezone("UTC")
+
+
+class TestDataBaseConnexion(unittest.TestCase):
+    def setUp(self) -> None:
+        # Initialize settings
+        config = Settings()
+        self.di = _DataInterface(config)
+
+        # Initialize database object
+        self.database = DataBase(config)
+        
+    def test_sql_db_available(self):
+        
+        assert self.di.check_sql_available() == True       
+        
+        
+    def test_get_prediction_jobs(self):
+        
+        pj_retriever = PredictionJobRetriever()
+        
+        pjs = pj_retriever.get_prediction_jobs()       
+        
+        
+    def test_get_pids_for_api_key(self):
+        
+        pj_retriever = PredictionJobRetriever()
+
+        pj_retriever.get_pids_for_api_key('random_api_key')
+    
+    
+    # def test_get_ean_for_pid(self):
+    
+    # def test_add_quantiles_to_prediction_jobs(self):
+    
+    # def test_get_systems_near_location(self):
+    
+    # def test_get_systems_by_pid(self):
+    
+    # def test_get_random_pv_systems(self):
+    
+    # def test_get_api_key_for_system(self):
+    
+    # def test_write_location(self):
+    
+    # def test_get_power_curve(self):
+    
+    # def test_get_energy_split_coefs(self):
+    
+    # def test_get_weather_forecast_locations(self):
+    
+    # def test_get_coordinates_of_location(self):
+        

--- a/tests/integration/test_database_connection.py
+++ b/tests/integration/test_database_connection.py
@@ -64,7 +64,6 @@ class TestDataBaseConnexion(unittest.TestCase):
 
     @unittest.skip  # Skip because it need the db to be set up
     def test_add_quantiles_to_prediction_jobs(self):
-
         pj_retriever = PredictionJobRetriever()
         pjs = pj_retriever.get_prediction_jobs()
 

--- a/tests/integration/test_database_connection.py
+++ b/tests/integration/test_database_connection.py
@@ -15,6 +15,11 @@ from openstef_dbc.data_interface import _DataInterface
 from openstef_dbc.database import DataBase
 from openstef.data_classes.prediction_job import PredictionJobDataClass
 from openstef_dbc.services.prediction_job import PredictionJobRetriever
+from openstef_dbc.services.systems import Systems
+from openstef_dbc.services.model_input import ModelInput
+from openstef_dbc.services.splitting import Splitting
+from openstef_dbc.services.weather import Weather
+from openstef_dbc.services.write import Write
 from tests.integration.mock_influx_db_admin import MockInfluxDBAdmin
 
 from tests.integration.settings import Settings
@@ -54,25 +59,72 @@ class TestDataBaseConnexion(unittest.TestCase):
         assert isinstance(response, list)
 
     
-    # def test_get_ean_for_pid(self):
+    def test_get_ean_for_pid(self):
     
-    # def test_add_quantiles_to_prediction_jobs(self):
+        pj_retriever = PredictionJobRetriever()
+
+        response = pj_retriever.get_ean_for_pid(1)
+        assert isinstance(response, list)
+
     
-    # def test_get_systems_near_location(self):
-    
-    # def test_get_systems_by_pid(self):
-    
-    # def test_get_random_pv_systems(self):
-    
-    # def test_get_api_key_for_system(self):
-    
-    # def test_write_location(self):
-    
-    # def test_get_power_curve(self):
-    
-    # def test_get_energy_split_coefs(self):
-    
-    # def test_get_weather_forecast_locations(self):
-    
-    # def test_get_coordinates_of_location(self):
+    def test_add_quantiles_to_prediction_jobs(self):
         
+        pj_retriever = PredictionJobRetriever()
+        pjs = pj_retriever.get_prediction_jobs()       
+
+        response = pj_retriever._add_quantiles_to_prediction_jobs(pjs)[0]
+        assert isinstance(response, PredictionJobDataClass)
+        assert hasattr(response, 'quantiles')
+    
+    def test_get_systems_near_location(self):
+        
+        system = Systems()
+        response = system.get_systems_near_location(location=[0.0,0.0])       
+        assert isinstance(response, pd.DataFrame)
+    
+    def test_get_systems_by_pid(self):
+        system = Systems()
+        response = system.get_systems_by_pid(pid = 1)
+        assert isinstance(response, pd.DataFrame)
+    
+    def test_get_random_pv_systems(self):
+        system = Systems()
+        response = system.get_random_pv_systems()
+        assert isinstance(response, pd.DataFrame)
+        
+    def test_get_api_key_for_system(self):
+        system = Systems()
+        response = system.get_api_key_for_system(sid='1')     
+        assert isinstance(response, str)
+        
+    def test_write_location(self):
+        write = Write()
+        # Mocking sql write execution
+        # TODO : How to mock writing but keep testing SQLAchemy execute method ?
+        # response = write.write_location(location_name="Random City", location = (0.0,0.0))
+    
+    def test_get_power_curve(self):
+        modelinput = ModelInput()
+        response = modelinput.get_power_curve(turbine_type='Enercon E101')
+        assert isinstance(response, dict)
+        for key in ['name','cut_in','cut_off','kind','manufacturer','peak_capacity','rated_power','slope_center','steepness']:
+            assert key in response
+    
+    def test_get_energy_split_coefs(self):
+        splitting = Splitting()
+        pj_retriever = PredictionJobRetriever()
+        pj = pj_retriever.get_prediction_jobs()[0]
+        response = splitting.get_energy_split_coefs(pj=pj)
+        
+        assert isinstance(response, dict)
+        
+    def test_get_weather_forecast_locations(self):
+        weather = Weather()
+        response = weather.get_weather_forecast_locations()
+        
+        assert isinstance(response, list)
+        
+    def test_get_coordinates_of_location(self):
+        weather = Weather()
+        response = weather._get_coordinates_of_location(location_name = 'Leeuwarden')
+        assert isinstance(response, tuple)

--- a/tests/integration/test_database_connection.py
+++ b/tests/integration/test_database_connection.py
@@ -10,7 +10,6 @@ import pandas as pd
 import numpy as np
 import unittest
 
-
 from openstef_dbc.data_interface import _DataInterface
 from openstef_dbc.database import DataBase
 from openstef.data_classes.prediction_job import PredictionJobDataClass
@@ -35,96 +34,95 @@ class TestDataBaseConnexion(unittest.TestCase):
 
         # Initialize database object
         self.database = DataBase(config)
-        
+
     def test_sql_db_available(self):
-        
-        assert self.di.check_sql_available() == True       
-        
-        
+
+        assert self.di.check_sql_available() == True
+
     def test_get_prediction_jobs(self):
-        
+
         pj_retriever = PredictionJobRetriever()
-        
-        response = pj_retriever.get_prediction_jobs()       
+
+        response = pj_retriever.get_prediction_jobs()
         assert isinstance(response, list)
         assert isinstance(response[0], PredictionJobDataClass)
 
-        
-        
     def test_get_pids_for_api_key(self):
-        
+
         pj_retriever = PredictionJobRetriever()
 
-        response = pj_retriever.get_pids_for_api_key('random_api_key')
+        response = pj_retriever.get_pids_for_api_key("random_api_key")
         assert isinstance(response, list)
 
-    
     def test_get_ean_for_pid(self):
-    
+
         pj_retriever = PredictionJobRetriever()
 
         response = pj_retriever.get_ean_for_pid(1)
         assert isinstance(response, list)
 
-    
     def test_add_quantiles_to_prediction_jobs(self):
-        
+
         pj_retriever = PredictionJobRetriever()
-        pjs = pj_retriever.get_prediction_jobs()       
+        pjs = pj_retriever.get_prediction_jobs()
 
         response = pj_retriever._add_quantiles_to_prediction_jobs(pjs)[0]
         assert isinstance(response, PredictionJobDataClass)
-        assert hasattr(response, 'quantiles')
-    
+        assert hasattr(response, "quantiles")
+
     def test_get_systems_near_location(self):
-        
+
         system = Systems()
-        response = system.get_systems_near_location(location=[0.0,0.0])       
+        response = system.get_systems_near_location(location=[0.0, 0.0])
         assert isinstance(response, pd.DataFrame)
-    
+
     def test_get_systems_by_pid(self):
         system = Systems()
-        response = system.get_systems_by_pid(pid = 1)
+        response = system.get_systems_by_pid(pid=1)
         assert isinstance(response, pd.DataFrame)
-    
+
     def test_get_random_pv_systems(self):
         system = Systems()
         response = system.get_random_pv_systems()
         assert isinstance(response, pd.DataFrame)
-        
+
     def test_get_api_key_for_system(self):
         system = Systems()
-        response = system.get_api_key_for_system(sid='1')     
+        response = system.get_api_key_for_system(sid="1")
         assert isinstance(response, str)
-        
-    def test_write_location(self):
-        write = Write()
-        # Mocking sql write execution
-        # TODO : How to mock writing but keep testing SQLAchemy execute method ?
-        # response = write.write_location(location_name="Random City", location = (0.0,0.0))
-    
+
     def test_get_power_curve(self):
         modelinput = ModelInput()
-        response = modelinput.get_power_curve(turbine_type='Enercon E101')
+        response = modelinput.get_power_curve(turbine_type="Enercon E101")
         assert isinstance(response, dict)
-        for key in ['name','cut_in','cut_off','kind','manufacturer','peak_capacity','rated_power','slope_center','steepness']:
+        for key in [
+            "name",
+            "cut_in",
+            "cut_off",
+            "kind",
+            "manufacturer",
+            "peak_capacity",
+            "rated_power",
+            "slope_center",
+            "steepness",
+        ]:
             assert key in response
-    
+
     def test_get_energy_split_coefs(self):
         splitting = Splitting()
         pj_retriever = PredictionJobRetriever()
         pj = pj_retriever.get_prediction_jobs()[0]
         response = splitting.get_energy_split_coefs(pj=pj)
-        
+
         assert isinstance(response, dict)
-        
+
     def test_get_weather_forecast_locations(self):
         weather = Weather()
         response = weather.get_weather_forecast_locations()
-        
+
         assert isinstance(response, list)
-        
+
     def test_get_coordinates_of_location(self):
         weather = Weather()
-        response = weather._get_coordinates_of_location(location_name = 'Leeuwarden')
+        response = weather._get_coordinates_of_location(location_name="Leeuwarden")
         assert isinstance(response, tuple)

--- a/tests/integration/test_database_connection.py
+++ b/tests/integration/test_database_connection.py
@@ -41,7 +41,6 @@ class TestDataBaseConnexion(unittest.TestCase):
 
     @unittest.skip  # Skip because it need the db to be set up
     def test_get_prediction_jobs(self):
-
         pj_retriever = PredictionJobRetriever()
 
         response = pj_retriever.get_prediction_jobs()

--- a/tests/integration/test_database_connection.py
+++ b/tests/integration/test_database_connection.py
@@ -49,7 +49,6 @@ class TestDataBaseConnexion(unittest.TestCase):
 
     @unittest.skip  # Skip because it need the db to be set up
     def test_get_pids_for_api_key(self):
-
         pj_retriever = PredictionJobRetriever()
 
         response = pj_retriever.get_pids_for_api_key("random_api_key")

--- a/tests/integration/test_database_connection.py
+++ b/tests/integration/test_database_connection.py
@@ -35,10 +35,12 @@ class TestDataBaseConnexion(unittest.TestCase):
         # Initialize database object
         self.database = DataBase(config)
 
+    @unittest.skip  # Skip because it need the db to be set up
     def test_sql_db_available(self):
 
         assert self.di.check_sql_available() == True
 
+    @unittest.skip  # Skip because it need the db to be set up
     def test_get_prediction_jobs(self):
 
         pj_retriever = PredictionJobRetriever()
@@ -47,6 +49,7 @@ class TestDataBaseConnexion(unittest.TestCase):
         assert isinstance(response, list)
         assert isinstance(response[0], PredictionJobDataClass)
 
+    @unittest.skip  # Skip because it need the db to be set up
     def test_get_pids_for_api_key(self):
 
         pj_retriever = PredictionJobRetriever()
@@ -54,6 +57,7 @@ class TestDataBaseConnexion(unittest.TestCase):
         response = pj_retriever.get_pids_for_api_key("random_api_key")
         assert isinstance(response, list)
 
+    @unittest.skip  # Skip because it need the db to be set up
     def test_get_ean_for_pid(self):
 
         pj_retriever = PredictionJobRetriever()
@@ -61,6 +65,7 @@ class TestDataBaseConnexion(unittest.TestCase):
         response = pj_retriever.get_ean_for_pid(1)
         assert isinstance(response, list)
 
+    @unittest.skip  # Skip because it need the db to be set up
     def test_add_quantiles_to_prediction_jobs(self):
 
         pj_retriever = PredictionJobRetriever()
@@ -70,27 +75,32 @@ class TestDataBaseConnexion(unittest.TestCase):
         assert isinstance(response, PredictionJobDataClass)
         assert hasattr(response, "quantiles")
 
+    @unittest.skip  # Skip because it need the db to be set up
     def test_get_systems_near_location(self):
 
         system = Systems()
         response = system.get_systems_near_location(location=[0.0, 0.0])
         assert isinstance(response, pd.DataFrame)
 
+    @unittest.skip  # Skip because it need the db to be set up
     def test_get_systems_by_pid(self):
         system = Systems()
         response = system.get_systems_by_pid(pid=1)
         assert isinstance(response, pd.DataFrame)
 
+    @unittest.skip  # Skip because it need the db to be set up
     def test_get_random_pv_systems(self):
         system = Systems()
         response = system.get_random_pv_systems()
         assert isinstance(response, pd.DataFrame)
 
+    @unittest.skip  # Skip because it need the db to be set up
     def test_get_api_key_for_system(self):
         system = Systems()
         response = system.get_api_key_for_system(sid="1")
         assert isinstance(response, str)
 
+    @unittest.skip  # Skip because it need the db to be set up
     def test_get_power_curve(self):
         modelinput = ModelInput()
         response = modelinput.get_power_curve(turbine_type="Enercon E101")
@@ -108,6 +118,7 @@ class TestDataBaseConnexion(unittest.TestCase):
         ]:
             assert key in response
 
+    @unittest.skip  # Skip because it need the db to be set up
     def test_get_energy_split_coefs(self):
         splitting = Splitting()
         pj_retriever = PredictionJobRetriever()
@@ -116,12 +127,14 @@ class TestDataBaseConnexion(unittest.TestCase):
 
         assert isinstance(response, dict)
 
+    @unittest.skip  # Skip because it need the db to be set up
     def test_get_weather_forecast_locations(self):
         weather = Weather()
         response = weather.get_weather_forecast_locations()
 
         assert isinstance(response, list)
 
+    @unittest.skip  # Skip because it need the db to be set up
     def test_get_coordinates_of_location(self):
         weather = Weather()
         response = weather._get_coordinates_of_location(location_name="Leeuwarden")

--- a/tests/integration/test_database_connection.py
+++ b/tests/integration/test_database_connection.py
@@ -73,7 +73,6 @@ class TestDataBaseConnexion(unittest.TestCase):
 
     @unittest.skip  # Skip because it need the db to be set up
     def test_get_systems_near_location(self):
-
         system = Systems()
         response = system.get_systems_near_location(location=[0.0, 0.0])
         assert isinstance(response, pd.DataFrame)


### PR DESCRIPTION
SQL Achemy 2.0 introduces a new way of sending requests.
With this PR, every Openstef-dbc SQL queries have been adapted to this new syntax.

Additionally, integration tests are proposed. for each "get" method using SQL queries.